### PR TITLE
[codex] RemoteConfig 리뷰 후속 개선

### DIFF
--- a/Sources/LaunchingService/Private/AppReleaseVersionProvider.swift
+++ b/Sources/LaunchingService/Private/AppReleaseVersionProvider.swift
@@ -1,0 +1,16 @@
+//
+//  AppReleaseVersionProvider.swift
+//
+//
+//  Created by SwiftMan on 2023/01/31.
+//
+
+protocol AppReleaseVersionProviding: Sendable {
+  func releaseVersion() throws -> String
+}
+
+struct MainBundleReleaseVersionProvider: AppReleaseVersionProviding {
+  func releaseVersion() throws -> String {
+    try MainBundle().releaseVersion()
+  }
+}

--- a/Sources/LaunchingService/Private/RemoteConfigClient.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigClient.swift
@@ -1,0 +1,41 @@
+//
+//  RemoteConfigClient.swift
+//
+//
+//  Created by SwiftMan on 2023/01/31.
+//
+
+import FirebaseRemoteConfig
+
+protocol RemoteConfigValueProviding: Sendable {
+  func stringValue(forKey key: String) -> String
+  func boolValue(forKey key: String) -> Bool
+}
+
+protocol RemoteConfigFetching: Sendable {
+  func fetchAndActivate() async throws
+}
+
+protocol RemoteConfigClient: RemoteConfigFetching, RemoteConfigValueProviding {
+}
+
+struct FirebaseRemoteConfigClient: RemoteConfigClient {
+  func fetchAndActivate() async throws {
+    let remoteConfig = RemoteConfig.remoteConfig()
+    _ = try await remoteConfig.fetchAndActivate()
+  }
+
+  func stringValue(forKey key: String) -> String {
+    RemoteConfig
+      .remoteConfig()
+      .configValue(forKey: key)
+      .stringValue
+  }
+
+  func boolValue(forKey key: String) -> Bool {
+    RemoteConfig
+      .remoteConfig()
+      .configValue(forKey: key)
+      .boolValue
+  }
+}

--- a/Sources/LaunchingService/Private/RemoteConfigForceUpdateParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigForceUpdateParser.swift
@@ -6,27 +6,33 @@
 //
 
 import Foundation
-import FirebaseRemoteConfig
 
 final class RemoteConfigForceUpdateParser: Sendable {
-  let keyStore: RemoteConfigRegisterdKeys
+  private let keyStore: RemoteConfigRegisterdKeys
+  private let valueProvider: any RemoteConfigValueProviding
   
-  init(keyStore: RemoteConfigRegisterdKeys) {
+  init(keyStore: RemoteConfigRegisterdKeys,
+       valueProvider: any RemoteConfigValueProviding = FirebaseRemoteConfigClient()) {
     self.keyStore = keyStore
+    self.valueProvider = valueProvider
   }
   
-  func parseAppUpdateInfo() throws -> AppUpdateInfo {
-    return AppUpdateInfo(version: try parseForceUpdateAppVersionKey(),
+  func parseAppUpdateInfo() -> AppUpdateInfo {
+    guard let forceDoneLinkURL = parseForceDoneLinkURL() else {
+      return .inactiveForceUpdate
+    }
+
+    return AppUpdateInfo(version: parseForceUpdateAppVersion() ?? "",
                          alertTitle: forceUpdateTitle,
                          alertMessage: forceUpdateMessage,
-                         alertDoneLinkURL: try parseForceDoneLinkURL())
+                         alertDoneLinkURL: forceDoneLinkURL)
   }
   
-  var parseBlackListVersions: [String] {
-    let blackListVersionString = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.forceUpdateKeys.blackListVersionsKey)
-      .stringValue
+  func parseBlackListVersions() -> [String] {
+    guard parseForceDoneLinkURL() != nil else { return [] }
+
+    let blackListVersionString = valueProvider
+      .stringValue(forKey: keyStore.forceUpdateKeys.blackListVersionsKey)
     
     return blackListVersionString
       .split(separator: ",")
@@ -34,47 +40,35 @@ final class RemoteConfigForceUpdateParser: Sendable {
       .filter { !$0.isEmpty }
   }
   
-  private func parseForceDoneLinkURL() throws -> URL {
-    guard let urlString = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.forceUpdateKeys.alertDoneLinkURLKey)
-      .stringValue
+  private func parseForceDoneLinkURL() -> URL? {
+    guard let urlString = valueProvider
+      .stringValue(forKey: keyStore.forceUpdateKeys.alertDoneLinkURLKey)
       .nilIfBlank
-    else {
-      throw LaunchingServiceError.notFoundLinkURLKey
-    }
-    
-    guard let url = URL(string: urlString) else {
-      throw LaunchingServiceError.invalidLinkURLValue
-    }
-    
-    return url
+    else { return nil }
+
+    return URL(string: urlString)
   }
 
-  private func parseForceUpdateAppVersionKey() throws -> String {
-    guard let forceUpdateAppVersion = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.forceUpdateKeys.appVersionKey)
-      .stringValue
+  private func parseForceUpdateAppVersion() -> String? {
+    valueProvider
+      .stringValue(forKey: keyStore.forceUpdateKeys.appVersionKey)
       .nilIfBlank
-    else {
-      throw LaunchingServiceError.notFoundForceUpdateAppVersionKey
-    }
-    
-    return forceUpdateAppVersion
   }
   
   private var forceUpdateTitle: String {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.forceUpdateKeys.alertTitleKey)
-      .stringValue
+    valueProvider.stringValue(forKey: keyStore.forceUpdateKeys.alertTitleKey)
   }
   
   private var forceUpdateMessage: String {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.forceUpdateKeys.alertMessageKey)
-      .stringValue
+    valueProvider.stringValue(forKey: keyStore.forceUpdateKeys.alertMessageKey)
+  }
+}
+
+private extension AppUpdateInfo {
+  static var inactiveForceUpdate: AppUpdateInfo {
+    AppUpdateInfo(version: "",
+                  alertTitle: "",
+                  alertMessage: "",
+                  alertDoneLinkURL: URL(string: "about:blank")!)
   }
 }

--- a/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
@@ -5,13 +5,23 @@
 //  Created by SwiftMan on 2023/02/10.
 //
 
-import FirebaseRemoteConfig
+import Foundation
 
 final class RemoteConfigNoticeParser: Sendable {
-  let keyStore: RemoteConfigRegisterdKeys
+  private static let dateFormatterLock = NSLock()
+  private static let dateFormatter: ISO8601DateFormatter = {
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.formatOptions = [.withInternetDateTime]
+    return dateFormatter
+  }()
+
+  private let keyStore: RemoteConfigRegisterdKeys
+  private let valueProvider: any RemoteConfigValueProviding
   
-  init(keyStore: RemoteConfigRegisterdKeys) {
+  init(keyStore: RemoteConfigRegisterdKeys,
+       valueProvider: any RemoteConfigValueProviding = FirebaseRemoteConfigClient()) {
     self.keyStore = keyStore
+    self.valueProvider = valueProvider
   }
   
   func parseNotice() -> NoticeInfo? {
@@ -32,60 +42,48 @@ final class RemoteConfigNoticeParser: Sendable {
   }
   
   private var noticeAlertTitle: String {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.noticeKeys.alertTitleKey)
-      .stringValue
+    valueProvider.stringValue(forKey: keyStore.noticeKeys.alertTitleKey)
   }
   
   private var noticeAlertMessage: String {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.noticeKeys.alertMessageKey)
-      .stringValue
+    valueProvider.stringValue(forKey: keyStore.noticeKeys.alertMessageKey)
   }
   
   private var noticeStartDate: Date? {
-    guard let startDateString = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.noticeKeys.startDateKey)
-      .stringValue
+    guard let startDateString = valueProvider
+      .stringValue(forKey: keyStore.noticeKeys.startDateKey)
       .nilIfBlank
     else { return nil }
     
-    let dateFormatter = ISO8601DateFormatter()
-    dateFormatter.formatOptions = [.withInternetDateTime]
-    return dateFormatter.date(from: startDateString)
+    return Self.date(from: startDateString)
   }
   
   private var noticeEndDate: Date? {
-    guard let endDateString = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.noticeKeys.endDateKey)
-      .stringValue
+    guard let endDateString = valueProvider
+      .stringValue(forKey: keyStore.noticeKeys.endDateKey)
       .nilIfBlank
     else { return nil }
     
-    let dateFormatter = ISO8601DateFormatter()
-    dateFormatter.formatOptions = [.withInternetDateTime]
-    return dateFormatter.date(from: endDateString)
+    return Self.date(from: endDateString)
   }
   
   private var noticeAlertDismissedTerminate: Bool {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.noticeKeys.alertDismissedTerminateKey)
-      .boolValue
+    valueProvider.boolValue(forKey: keyStore.noticeKeys.alertDismissedTerminateKey)
   }
   
   private var noticeAlertDoneURL: URL? {
-    guard let urlString = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.noticeKeys.alertDoneURLKey)
-      .stringValue
+    guard let urlString = valueProvider
+      .stringValue(forKey: keyStore.noticeKeys.alertDoneURLKey)
       .nilIfBlank
     else { return nil }
     
     return URL(string: urlString)
+  }
+
+  private static func date(from string: String) -> Date? {
+    dateFormatterLock.lock()
+    defer { dateFormatterLock.unlock() }
+
+    return dateFormatter.date(from: string)
   }
 }

--- a/Sources/LaunchingService/Private/RemoteConfigOptionalUpdateParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigOptionalUpdateParser.swift
@@ -6,13 +6,15 @@
 //
 
 import Foundation
-import FirebaseRemoteConfig
 
 final class RemoteConfigOptionalUpdateParser: Sendable {
-  let keyStore: RemoteConfigRegisterdKeys
+  private let keyStore: RemoteConfigRegisterdKeys
+  private let valueProvider: any RemoteConfigValueProviding
   
-  init(keyStore: RemoteConfigRegisterdKeys) {
+  init(keyStore: RemoteConfigRegisterdKeys,
+       valueProvider: any RemoteConfigValueProviding = FirebaseRemoteConfigClient()) {
     self.keyStore = keyStore
+    self.valueProvider = valueProvider
   }
   
   func parseAppUpdateInfo() -> AppUpdateInfo {
@@ -30,18 +32,14 @@ final class RemoteConfigOptionalUpdateParser: Sendable {
   }
   
   private func parseOptionalUpdateAppVersion() -> String? {
-    return RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.optionalUpdateKeys.appVersionKey)
-      .stringValue
+    return valueProvider
+      .stringValue(forKey: keyStore.optionalUpdateKeys.appVersionKey)
       .nilIfBlank
   }
   
   private func parseOptionalDoneLinkURL() -> URL? {
-    guard let urlString = RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.optionalUpdateKeys.alertDoneLinkURLKey)
-      .stringValue
+    guard let urlString = valueProvider
+      .stringValue(forKey: keyStore.optionalUpdateKeys.alertDoneLinkURLKey)
       .nilIfBlank
     else { return nil }
 
@@ -49,17 +47,11 @@ final class RemoteConfigOptionalUpdateParser: Sendable {
   }
   
   private var optionalUpdateTitle: String {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.optionalUpdateKeys.alertTitleKey)
-      .stringValue
+    valueProvider.stringValue(forKey: keyStore.optionalUpdateKeys.alertTitleKey)
   }
   
   private var optionalUpdateMessage: String {
-    RemoteConfig
-      .remoteConfig()
-      .configValue(forKey: keyStore.optionalUpdateKeys.alertMessageKey)
-      .stringValue
+    valueProvider.stringValue(forKey: keyStore.optionalUpdateKeys.alertMessageKey)
   }
 }
 

--- a/Sources/LaunchingService/Private/RemoteConfigParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigParser.swift
@@ -8,23 +8,32 @@
 import Dependencies
 
 final class RemoteConfigParser: Sendable {
-  func parse() throws -> Launching {
+  private let valueProvider: any RemoteConfigValueProviding
+
+  init(valueProvider: any RemoteConfigValueProviding = FirebaseRemoteConfigClient()) {
+    self.valueProvider = valueProvider
+  }
+
+  func parse() -> Launching {
     @Dependency(\.remoteConfigRegisterdKeys)
     var remoteConfigRegisterdKeys
 
-    let forceParser = RemoteConfigForceUpdateParser(keyStore: remoteConfigRegisterdKeys)
-    let noticeParser = RemoteConfigNoticeParser(keyStore: remoteConfigRegisterdKeys)
+    let forceParser = RemoteConfigForceUpdateParser(keyStore: remoteConfigRegisterdKeys,
+                                                    valueProvider: valueProvider)
+    let noticeParser = RemoteConfigNoticeParser(keyStore: remoteConfigRegisterdKeys,
+                                                valueProvider: valueProvider)
 
-    let forceUpdate = try forceParser.parseAppUpdateInfo()
+    let forceUpdate = forceParser.parseAppUpdateInfo()
 
-    let optionalParser = RemoteConfigOptionalUpdateParser(keyStore: remoteConfigRegisterdKeys)
+    let optionalParser = RemoteConfigOptionalUpdateParser(keyStore: remoteConfigRegisterdKeys,
+                                                          valueProvider: valueProvider)
     let optionalUpdate = optionalParser.parseAppUpdateInfo()
 
     let notice = noticeParser.parseNotice()
 
     return Launching(forceUpdate: forceUpdate,
                      optionalUpdate: optionalUpdate,
-                     blackListVersions: forceParser.parseBlackListVersions,
+                     blackListVersions: forceParser.parseBlackListVersions(),
                      notice: notice)
   }
 }

--- a/Sources/LaunchingService/Public/LaunchingService.swift
+++ b/Sources/LaunchingService/Public/LaunchingService.swift
@@ -5,14 +5,22 @@
 //  Created by SwiftMan on 2023/01/31.
 //
 
-import FirebaseRemoteConfig
-import Dependencies
-
 /// 앱을 구성하기 전 외부로 부터 설정을 가져와 앱 상태를 반환하는 서비스 입니다.
 @available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
 public final class LaunchingService: LaunchingInteractable, Sendable {
+  private let remoteConfigClient: any RemoteConfigClient
+  private let appVersionProvider: any AppReleaseVersionProviding
+
   /// Creates an instance with the given alignment.
   public init() {
+    self.remoteConfigClient = FirebaseRemoteConfigClient()
+    self.appVersionProvider = MainBundleReleaseVersionProvider()
+  }
+
+  init(remoteConfigClient: any RemoteConfigClient,
+       appVersionProvider: any AppReleaseVersionProviding) {
+    self.remoteConfigClient = remoteConfigClient
+    self.appVersionProvider = appVersionProvider
   }
 
   /// Firebase - RemoteConfig 의 값을 가져오고 계산 된 앱의 상태를 반환 합니다.
@@ -20,12 +28,14 @@ public final class LaunchingService: LaunchingInteractable, Sendable {
   /// - Returns: ``AppUpdateStatus`` - `valid`, `forceUpdate`, `optionalUpdate`
   /// - Throws: ``LaunchingServiceError``
   public func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
-    let remoteConfig = RemoteConfig.remoteConfig()
-    _ = try await remoteConfig.fetch(withExpirationDuration: 0)
-    _ = try await remoteConfig.activate()
+    do {
+      try await remoteConfigClient.fetchAndActivate()
+    } catch {
+      // Continue with the currently active or default RemoteConfig values.
+    }
 
-    let releaseVersion = try MainBundle().releaseVersion()
-    let launching = try RemoteConfigParser().parse()
+    let releaseVersion = try appVersionProvider.releaseVersion()
+    let launching = RemoteConfigParser(valueProvider: remoteConfigClient).parse()
     return compare(releaseVersion: releaseVersion, launching: launching)
   }
 }

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -1,0 +1,165 @@
+//
+//  RemoteConfigParserTests.swift
+//
+//
+//  Created by SwiftMan on 2023/02/10.
+//
+
+import XCTest
+@testable import LaunchingService
+
+@MainActor
+final class RemoteConfigParserTests: XCTestCase {
+  func testForceUpdateParserKeepsAlertInfoWhenForceVersionIsMissing() {
+    let parser = RemoteConfigForceUpdateParser(
+      keyStore: RemoteConfigRegisterdKeys(),
+      valueProvider: RemoteConfigClientMock(strings: [
+        "forceUpdateAlertTitleKey": "Force update",
+        "forceUpdateAlertMessageKey": "Please update",
+        "forceUpdateAlertDoneLinkURLKey": "https://example.com/force"
+      ])
+    )
+
+    let appUpdateInfo = parser.parseAppUpdateInfo()
+
+    XCTAssertEqual(appUpdateInfo.version, "")
+    XCTAssertEqual(appUpdateInfo.alertTitle, "Force update")
+    XCTAssertEqual(appUpdateInfo.alertMessage, "Please update")
+    XCTAssertEqual(appUpdateInfo.alertDoneLinkURL, URL(string: "https://example.com/force")!)
+  }
+
+  func testForceUpdateParserReturnsInactiveInfoWhenDoneURLIsMissing() {
+    let parser = RemoteConfigForceUpdateParser(
+      keyStore: RemoteConfigRegisterdKeys(),
+      valueProvider: RemoteConfigClientMock(strings: [
+        "forceUpdateAppVersionKey": "2.0.0",
+        "forceUpdateAlertTitleKey": "Force update",
+        "forceUpdateAlertMessageKey": "Please update"
+      ])
+    )
+
+    let appUpdateInfo = parser.parseAppUpdateInfo()
+
+    XCTAssertEqual(appUpdateInfo.version, "")
+    XCTAssertEqual(appUpdateInfo.alertDoneLinkURL, URL(string: "about:blank")!)
+  }
+
+  func testForceUpdateParserDisablesBlackListVersionsWhenDoneURLIsMissing() {
+    let parser = RemoteConfigForceUpdateParser(
+      keyStore: RemoteConfigRegisterdKeys(),
+      valueProvider: RemoteConfigClientMock(strings: [
+        "blackListVersionsKey": "1.0.0, 1.1.0"
+      ])
+    )
+
+    XCTAssertEqual(parser.parseBlackListVersions(), [])
+  }
+
+  func testRemoteConfigParserUsesInjectedValuesWithoutFirebase() {
+    let parser = RemoteConfigParser(
+      valueProvider: RemoteConfigClientMock(strings: [
+        "forceUpdateAppVersionKey": "2.0.0",
+        "forceUpdateAlertTitleKey": "Force update",
+        "forceUpdateAlertMessageKey": "Please update",
+        "forceUpdateAlertDoneLinkURLKey": "https://example.com/force",
+        "optionalUpdateAppVersionKey": "1.5.0",
+        "optionalUpdateAlertTitleKey": "Optional update",
+        "optionalUpdateAlertMessageKey": "A new version is available",
+        "optionalUpdateAlertDoneLinkURLKey": "https://example.com/optional",
+        "blackListVersionsKey": " 1.0.0, , 1.1.0 "
+      ])
+    )
+
+    let launching = parser.parse()
+
+    XCTAssertEqual(launching.forceUpdate.version, "2.0.0")
+    XCTAssertEqual(launching.forceUpdate.alertTitle, "Force update")
+    XCTAssertEqual(launching.forceUpdate.alertDoneLinkURL, URL(string: "https://example.com/force")!)
+    XCTAssertEqual(launching.optionalUpdate.version, "1.5.0")
+    XCTAssertEqual(launching.blackListVersions, ["1.0.0", "1.1.0"])
+    XCTAssertNil(launching.notice)
+  }
+
+  func testFetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
+    let remoteConfigClient = RemoteConfigClientMock(
+      strings: [
+        "optionalUpdateAppVersionKey": "2.0.0",
+        "optionalUpdateAlertTitleKey": "Optional update",
+        "optionalUpdateAlertMessageKey": "A new version is available",
+        "optionalUpdateAlertDoneLinkURLKey": "https://example.com/optional"
+      ],
+      fetchError: RemoteConfigClientMockError.fetchFailed
+    )
+    let service = LaunchingService(
+      remoteConfigClient: remoteConfigClient,
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+    )
+
+    let status = try await service.fetchAppUpdateStatus()
+
+    XCTAssertEqual(
+      status,
+      .optionalUpdateRequired(
+        UpdateAlert(title: "Optional update",
+                    message: "A new version is available",
+                    alertDoneLinkURL: URL(string: "https://example.com/optional")!)
+      )
+    )
+  }
+
+  func testFetchAppUpdateStatusDoesNotForceUpdateFromBlackListWhenForceURLIsMissing() async throws {
+    let remoteConfigClient = RemoteConfigClientMock(
+      strings: [
+        "blackListVersionsKey": "1.0.0"
+      ]
+    )
+    let service = LaunchingService(
+      remoteConfigClient: remoteConfigClient,
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+    )
+
+    let status = try await service.fetchAppUpdateStatus()
+
+    XCTAssertEqual(status, .valid)
+  }
+}
+
+private enum RemoteConfigClientMockError: Error {
+  case fetchFailed
+}
+
+private struct RemoteConfigClientMock: RemoteConfigClient {
+  let strings: [String: String]
+  let bools: [String: Bool]
+  let fetchError: RemoteConfigClientMockError?
+
+  init(strings: [String: String] = [:],
+       bools: [String: Bool] = [:],
+       fetchError: RemoteConfigClientMockError? = nil) {
+    self.strings = strings
+    self.bools = bools
+    self.fetchError = fetchError
+  }
+
+  func fetchAndActivate() async throws {
+    if let fetchError {
+      throw fetchError
+    }
+  }
+
+  func stringValue(forKey key: String) -> String {
+    strings[key] ?? ""
+  }
+
+  func boolValue(forKey key: String) -> Bool {
+    bools[key] ?? false
+  }
+}
+
+private struct AppReleaseVersionProviderMock: AppReleaseVersionProviding {
+  let version: String
+
+  func releaseVersion() throws -> String {
+    version
+  }
+}


### PR DESCRIPTION
## 개요

PR #10 머지 후 새 PR에서 처리하기로 한 RemoteConfig 코드리뷰 후속 개선입니다.

이 PR은 Firebase RemoteConfig 메이저 업데이트 자체가 아니라, 런칭 경로의 복원력과 테스트 가능성을 보강하는 작은 후속 변경입니다.

## 수정 사항

- `fetch(withExpirationDuration: 0)` 강제 fetch를 제거하고 Firebase RemoteConfig의 기본 캐시 정책을 따르는 `fetch()`로 변경했습니다.
- `fetch` 또는 `activate` 실패 시 앱 진입이 바로 막히지 않도록 현재 활성화된 값 또는 기본값으로 파싱을 계속하는 fallback을 추가했습니다.
- Firebase RemoteConfig 값 제공과 fetch/activate 역할을 `RemoteConfigClient`로 분리했습니다.
- 앱 버전 조회 역할을 `AppReleaseVersionProviding`으로 분리해 `LaunchingService`를 Firebase/Bundle 싱글턴 없이 테스트할 수 있게 했습니다.
- 강제 업데이트 RemoteConfig 값이 비어 있거나 URL이 없으면 throw 대신 비활성 `AppUpdateInfo`로 fallback하도록 변경했습니다.
- 공지 날짜 파싱의 `ISO8601DateFormatter`를 재사용하도록 정리했습니다.
- `parseBlackListVersions`를 계산 프로퍼티에서 메서드로 변경해 파싱 네이밍을 일관되게 맞췄습니다.

## 코드리뷰 반영/판단

- 해결: RemoteConfig fetch 실패 또는 throttling 시 앱 진입이 막힐 수 있다는 지적은 fallback 처리와 `fetch()` 기본 캐시 정책 적용으로 반영했습니다.
- 해결: 강제 업데이트 RemoteConfig 키가 optional인데 누락 시 throw로 앱 진입이 중단된다는 지적은 비활성 모델 fallback으로 반영했습니다.
- 해결: Firebase 싱글턴에 강하게 결합되어 순수 파서 테스트가 어렵다는 지적은 `RemoteConfigValueProviding`/`RemoteConfigClient` 주입과 단위 테스트 추가로 반영했습니다.
- 해결: `ISO8601DateFormatter` 반복 생성 지적은 static 재사용으로 반영했습니다.
- 해결: `parseBlackListVersions` 네이밍 지적은 메서드 형태로 정리했습니다.
- 유지: `BlackListVersionChecker`의 trim 제거 제안은 public `compare(releaseVersion:launching:)`가 외부에서 직접 구성된 `Launching`도 받는 구조라 방어 로직을 유지했습니다. parser 경로만 전제로 한 부분 오탐으로 판단했습니다.

## 검증

- `swift build` 통과
- `swift test` 통과: 44 tests, 0 failures
- `sh -n GeneratingDocumentationSite` 통과
- `./GeneratingDocumentationSite` 통과
- `git diff --check` 통과

DocC는 `.build/docc-site/LaunchingService`에 생성되며, 이 repo에는 `docs/` 또는 `.doccarchive` 추적 변경을 만들지 않았습니다.

## PR #10 머지/배포 확인

- PR #10은 `ac6dde0`으로 main에 머지되었습니다.
- `LaunchingService`의 main push `Swift` workflow와 `Deploy DocC` workflow가 모두 성공했습니다.
- `swift-man/docs`의 `gh-pages/LaunchingService`에 DocC 파일이 배포됨을 확인했습니다.
- `swift-man/docs` Pages source가 `main /`으로 되어 있어 공개 URL이 404였고, `gh-pages /`로 맞춘 뒤 Pages build가 성공했습니다.
- `https://docs.gorani.me/LaunchingService/documentation/launchingservice/?v=ac6dde0` 응답 200 및 `/LaunchingService/` baseUrl을 확인했습니다.
