### PR TITLE
[codex] DocC 배포 브랜치를 docs main으로 수정

### DIFF
--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -27,7 +27,8 @@ jobs:
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
           external_repository: swift-man/docs
-          publish_branch: gh-pages
+          publish_branch: main
           publish_dir: ./.build/docc-site/LaunchingService
           destination_dir: LaunchingService
+          keep_files: true
           commit_message: "Deploy LaunchingService DocC from ${{ github.repository }}@${{ github.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@
 ```
 
 - Do not commit generated DocC output. `GeneratingDocumentationSite` writes the static site to `.build/docc-site/LaunchingService` and removes local `docs/` and `.doccarchive` outputs.
-- The `Deploy DocC` GitHub Action publishes the generated site to `swift-man/docs` under the `LaunchingService/` directory.
+- The `Deploy DocC` GitHub Action publishes the generated site to the `main` branch of `swift-man/docs` under the `LaunchingService/` directory.
+- Keep `keep_files: true` in that workflow so other packages already deployed to `swift-man/docs` are not removed.
 - `swift-man/docs` uses the `docs.gorani.me` custom domain, so DocC static hosting base path should remain `LaunchingService`, not `docs/LaunchingService`.
 - The workflow requires a `DOCS_DEPLOY_KEY` repository secret. Register the matching public key as a writable deploy key in `swift-man/docs`.
 


### PR DESCRIPTION
## 개요

`swift-man/docs` 저장소의 기본 브랜치 `main`에서 `LaunchingService/` 폴더가 보이지 않는 문제를 수정합니다.

기존 workflow는 `swift-man/docs`의 `gh-pages` 브랜치로 배포하고 있었습니다. 그래서 공개 URL은 동작하지만, GitHub UI에서 기본으로 보이는 `main` 브랜치에는 `LaunchingService/` 폴더가 없었습니다.

## 변경 사항

- `.github/workflows/deploy-docc.yml`의 `publish_branch`를 `gh-pages`에서 `main`으로 변경했습니다.
- `destination_dir: LaunchingService`는 유지했습니다.
- `keep_files: true`를 추가해 `swift-man/docs/main`에 이미 있는 `LaunchingView`, `KoreanLunarSolarConverter` 등 다른 문서 폴더를 보존하도록 했습니다.
- `AGENTS.md`에 중앙 docs repo의 `main` 브랜치 배포와 `keep_files: true` 유지 규칙을 문서화했습니다.

## 확인한 원인

- `swift-man/docs/main`에는 `LaunchingView`, `KoreanLunarSolarConverter`가 있지만 `LaunchingService`가 없었습니다.
- `swift-man/docs/gh-pages`에는 `LaunchingService`가 있었습니다.
- 따라서 배포 브랜치가 중앙 docs repo 운영 브랜치와 어긋나 있었습니다.

## 검증

- `sh -n GeneratingDocumentationSite` 통과
- `./GeneratingDocumentationSite` 통과
- `swift test` 통과: 46 tests, 0 failures
- `git diff --check` 통과

머지 후 main push의 `Deploy DocC` workflow를 확인하고, `swift-man/docs/main/LaunchingService` 생성 여부와 공개 URL을 다시 확인하겠습니다.
