### PR TITLE
chore. Swift Testing 기반 테스트로 전환

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
@@ -8,13 +8,6 @@
 import Foundation
 
 final class RemoteConfigNoticeParser: Sendable {
-  private static let dateFormatterLock = NSLock()
-  private static let dateFormatter: ISO8601DateFormatter = {
-    let dateFormatter = ISO8601DateFormatter()
-    dateFormatter.formatOptions = [.withInternetDateTime]
-    return dateFormatter
-  }()
-
   private let keyStore: RemoteConfigRegisterdKeys
   private let valueProvider: any RemoteConfigValueProviding
   
@@ -81,8 +74,8 @@ final class RemoteConfigNoticeParser: Sendable {
   }
 
   private static func date(from string: String) -> Date? {
-    dateFormatterLock.lock()
-    defer { dateFormatterLock.unlock() }
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.formatOptions = [.withInternetDateTime]
 
     return dateFormatter.date(from: string)
   }

--- a/Tests/LaunchingServiceTests/BlackListTests.swift
+++ b/Tests/LaunchingServiceTests/BlackListTests.swift
@@ -5,89 +5,90 @@
 //  Created by SwiftMan on 2023/02/11.
 //
 
-import XCTest
+import Testing
 import LaunchingService
 
+@Suite("BlackList")
 @MainActor
-final class BlackListTests: LaunchingServiceTests {
-  func testBlackListRequired_0() async throws {
-    await tests(releaseVersion: "2.3.10",
-                    forceVersion: "0.0.9",
-                    optionalUpdate: "0.0.5",
-                    blackListVersions: ["2.3.9", "2.3.10", "2.3.11"],
-                    notice: nil,
-                    isEqualStatus: .forcedUpdateRequired(.mock))
+struct BlackListTests {
+  @Test func blackListRequired_0() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "2.3.10",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "0.0.5",
+                                    blackListVersions: ["2.3.9", "2.3.10", "2.3.11"],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
 
-  func testBlackListRequired_1() async throws {
-    await tests(releaseVersion: "12.3",
-                    forceVersion: "11.0.9",
-                    optionalUpdate: "15.0.5",
-                    blackListVersions: ["12.3.0", "12.3", "12"],
-                    notice: nil,
-                    isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func blackListRequired_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "12.3",
+                                    forceVersion: "11.0.9",
+                                    optionalUpdate: "15.0.5",
+                                    blackListVersions: ["12.3.0", "12.3", "12"],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
 
-  func testBlackListRequired_2() async throws {
-    await tests(releaseVersion: "1.0.10",
-                    forceVersion: "0.0.9",
-                    optionalUpdate: "0.0.5",
-                    blackListVersions: ["2.3.9", "2.3.10", "1.0.10"],
-                    notice: nil,
-                    isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func blackListRequired_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.10",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "0.0.5",
+                                    blackListVersions: ["2.3.9", "2.3.10", "1.0.10"],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
 
-  func testBlackListRequired_3() async throws {
-    await tests(releaseVersion: "0.3.10",
-                    forceVersion: "0.0.9",
-                    optionalUpdate: "0.0.5",
-                    blackListVersions: ["0.3.10"],
-                    notice: nil,
-                    isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func blackListRequired_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "0.3.10",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "0.0.5",
+                                    blackListVersions: ["0.3.10"],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
 
-  func testBlackListRequiredWithWhitespace() async throws {
-    await tests(releaseVersion: "1.2.0",
-                    forceVersion: "0.0.9",
-                    optionalUpdate: "0.0.5",
-                    blackListVersions: ["1.0.0", " 1.2.0 ", "2.0.0"],
-                    notice: nil,
-                    isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func blackListRequiredWithWhitespace() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.2.0",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "0.0.5",
+                                    blackListVersions: ["1.0.0", " 1.2.0 ", "2.0.0"],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
 
-  func testBlackListVersionValid_1() async throws {
-    await tests(releaseVersion: "2.0.0",
-                    forceVersion: "2.0.0",
-                    optionalUpdate: "",
-                    blackListVersions: ["1.9.1"],
-                    notice: nil,
-                    isEqualStatus: .valid)
+  @Test func blackListVersionValid_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "2.0.0",
+                                    forceVersion: "2.0.0",
+                                    optionalUpdate: "",
+                                    blackListVersions: ["1.9.1"],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
 
-  func testBlackListVersionValid_2() async throws {
-    await tests(releaseVersion: "1.0.0",
-                    forceVersion: "0.0.9",
-                    optionalUpdate: "0",
-                    blackListVersions: ["1.0.1"],
-                    notice: nil,
-                    isEqualStatus: .valid)
+  @Test func blackListVersionValid_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "0",
+                                    blackListVersions: ["1.0.1"],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
 
-  func testBlackListVersionValid_3() async throws {
-    await tests(releaseVersion: "1.0.0",
-                    forceVersion: "0.1",
-                    optionalUpdate: "",
-                    blackListVersions: [],
-                    notice: nil,
-                    isEqualStatus: .valid)
+  @Test func blackListVersionValid_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.1",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
 
-  func testBlackListVersionValid_4() async throws {
-    await tests(releaseVersion: "1.0.0",
-                    forceVersion: "0.1",
-                    optionalUpdate: "",
-                    blackListVersions: [""],
-                    notice: nil,
-                    isEqualStatus: .valid)
+  @Test func blackListVersionValid_4() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.1",
+                                    optionalUpdate: "",
+                                    blackListVersions: [""],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
 }

--- a/Tests/LaunchingServiceTests/ForceUpdateTests.swift
+++ b/Tests/LaunchingServiceTests/ForceUpdateTests.swift
@@ -5,71 +5,72 @@
 //  Created by SwiftMan on 2023/02/11.
 //
 
-import XCTest
+import Testing
 import LaunchingService
 
+@Suite("ForceUpdate")
 @MainActor
-final class ForceUpdateTests: LaunchingServiceTests {
-  func testAllVersionIsEmpty_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+struct ForceUpdateTests {
+  @Test func allVersionIsEmpty_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
   
-  func testForceVersionRequired_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "1.0.1",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func forceVersionRequired_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "1.0.1",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
   
-  func testForceVersionRequired_2() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "1.0.1",
-                optionalUpdate: "2.0.0",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func forceVersionRequired_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "1.0.1",
+                                    optionalUpdate: "2.0.0",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
   
-  func testForceVersionRequired_3() async throws {
-    await tests(releaseVersion: "1.0",
-                forceVersion: "2.0.5",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func forceVersionRequired_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0",
+                                    forceVersion: "2.0.5",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
   
-  func testForceVersionValid_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "1.0.0",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+  @Test func forceVersionValid_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "1.0.0",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
   
-  func testForceVersionValid_2() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "0.0.9",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+  @Test func forceVersionValid_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
   
-  func testForceVersionValid_3() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "0.1",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+  @Test func forceVersionValid_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.1",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
 }

--- a/Tests/LaunchingServiceTests/LaunchingServiceTests.swift
+++ b/Tests/LaunchingServiceTests/LaunchingServiceTests.swift
@@ -5,65 +5,60 @@
 //  Created by SwiftMan on 2023/02/10.
 //
 
-import XCTest
+import Foundation
+import Testing
 import LaunchingService
 
+@Suite("LaunchingService")
 @MainActor
-class LaunchingServiceTests: XCTestCase {
-  var service: LaunchingInteractable?
-  
-  func testRemoteConfigDataAllVersionIsEmpty_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+struct LaunchingServiceTests {
+  @Test func remoteConfigDataAllVersionIsEmpty() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
   
-  func testRemoteConfigDataForceVersionIsEmpty_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "1.0.1",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .forcedUpdateRequired(.mock))
+  @Test func remoteConfigDataForceVersionIsEmpty() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "1.0.1",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
   
-  func testRemoteConfigDataOptionalVersionIsEmpty_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "",
-                optionalUpdate: "1.0.1",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .optionalUpdateRequired(.mock))
-  }
-  
-  func tests(releaseVersion: String,
-             forceVersion: String,
-             optionalUpdate: String,
-             blackListVersions: [String],
-             notice: NoticeInfo?,
-             isEqualStatus: AppUpdateStatus) async {
-    service = LaunchingServiceMock(releaseVersion: releaseVersion,
-                                   launching: Launching(forceUpdate: AppUpdateInfo(version: forceVersion,
-                                                                                   alertTitle: "",
-                                                                                   alertMessage: "",
-                                                                                   alertDoneLinkURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
-                                                        optionalUpdate: AppUpdateInfo(version: optionalUpdate,
-                                                                                      alertTitle: "",
-                                                                                      alertMessage: "",
-                                                                                      alertDoneLinkURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
-                                                        blackListVersions: blackListVersions,
-                                                        notice: notice
-                                   ))
-    
-    do {
-      let appStatus = try await service?.fetchAppUpdateStatus()
-      XCTAssertEqual(appStatus, isEqualStatus)
-    } catch {
-      XCTFail("Wrong error")
-    }
+  @Test func remoteConfigDataOptionalVersionIsEmpty() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "",
+                                    optionalUpdate: "1.0.1",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .optionalUpdateRequired(.mock))
   }
 }
 
+@MainActor
+func expectAppUpdateStatus(releaseVersion: String,
+                           forceVersion: String,
+                           optionalUpdate: String,
+                           blackListVersions: [String],
+                           notice: NoticeInfo?,
+                           isEqualStatus: AppUpdateStatus) async throws {
+  let service = LaunchingServiceMock(releaseVersion: releaseVersion,
+                                     launching: Launching(forceUpdate: AppUpdateInfo(version: forceVersion,
+                                                                                     alertTitle: "",
+                                                                                     alertMessage: "",
+                                                                                     alertDoneLinkURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
+                                                          optionalUpdate: AppUpdateInfo(version: optionalUpdate,
+                                                                                        alertTitle: "",
+                                                                                        alertMessage: "",
+                                                                                        alertDoneLinkURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
+                                                          blackListVersions: blackListVersions,
+                                                          notice: notice))
+
+  let appStatus = try await service.fetchAppUpdateStatus()
+  #expect(appStatus == isEqualStatus)
+}

--- a/Tests/LaunchingServiceTests/NoticeTests.swift
+++ b/Tests/LaunchingServiceTests/NoticeTests.swift
@@ -5,55 +5,57 @@
 //  Created by SwiftMan on 2023/02/11.
 //
 
-import XCTest
+import Foundation
+import Testing
 import LaunchingService
 
+@Suite("Notice")
 @MainActor
-final class NoticeTests: LaunchingServiceTests {
-  func testNotice_1() async throws {
+struct NoticeTests {
+  @Test func notice_1() async throws {
     let title = "title"
     let message = "message"
     let isAppTerminated = true
     let doneURL = URL(string: "https://github.com/swift-man/LaunchingService")!
     
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: NoticeInfo(title: title,
-                                   message: message,
-                                   isAppTerminated: isAppTerminated,
-                                   dateRange: Date().addingTimeInterval(-5000) ... Date().addingTimeInterval(5000),
-                                   doneURL: doneURL),
-                isEqualStatus: .notice(NoticeAlert(title: title,
-                                                   message: message,
-                                                   isAppTerminated: isAppTerminated,
-                                                   doneURL: doneURL)))
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: NoticeInfo(title: title,
+                                                       message: message,
+                                                       isAppTerminated: isAppTerminated,
+                                                       dateRange: Date().addingTimeInterval(-5000) ... Date().addingTimeInterval(5000),
+                                                       doneURL: doneURL),
+                                    isEqualStatus: .notice(NoticeAlert(title: title,
+                                                                       message: message,
+                                                                       isAppTerminated: isAppTerminated,
+                                                                       doneURL: doneURL)))
   }
   
-  func testNotice_2() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: NoticeInfo(title: "title",
-                                   message: "message",
-                                   isAppTerminated: true,
-                                   dateRange: Date().addingTimeInterval(5000) ... Date().addingTimeInterval(15000),
-                                   doneURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
-                isEqualStatus: .valid)
+  @Test func notice_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: NoticeInfo(title: "title",
+                                                       message: "message",
+                                                       isAppTerminated: true,
+                                                       dateRange: Date().addingTimeInterval(5000) ... Date().addingTimeInterval(15000),
+                                                       doneURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
+                                    isEqualStatus: .valid)
   }
   
-  func testNotice_3() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "",
-                optionalUpdate: "",
-                blackListVersions: [],
-                notice: NoticeInfo(title: "title",
-                                   message: "message",
-                                   isAppTerminated: true,
-                                   dateRange: Date().addingTimeInterval(-15000) ... Date().addingTimeInterval(-10000),
-                                   doneURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
-                isEqualStatus: .valid)
+  @Test func notice_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "",
+                                    optionalUpdate: "",
+                                    blackListVersions: [],
+                                    notice: NoticeInfo(title: "title",
+                                                       message: "message",
+                                                       isAppTerminated: true,
+                                                       dateRange: Date().addingTimeInterval(-15000) ... Date().addingTimeInterval(-10000),
+                                                       doneURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
+                                    isEqualStatus: .valid)
   }
 }

--- a/Tests/LaunchingServiceTests/OptionalUpdateTests.swift
+++ b/Tests/LaunchingServiceTests/OptionalUpdateTests.swift
@@ -5,62 +5,63 @@
 //  Created by SwiftMan on 2023/02/11.
 //
 
-import XCTest
+import Testing
 import LaunchingService
 
+@Suite("OptionalUpdate")
 @MainActor
-final class OptionalUpdateTests: LaunchingServiceTests {
-  func testDataOptionalVersionRequired_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "1.0.1",
-                optionalUpdate: "1.0.1",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .forcedUpdateRequired(.mock))
+struct OptionalUpdateTests {
+  @Test func dataOptionalVersionRequired_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "1.0.1",
+                                    optionalUpdate: "1.0.1",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .forcedUpdateRequired(.mock))
   }
   
-  func testDataOptionalVersionRequired_2() async throws {
-    await tests(releaseVersion: "2.0.0",
-                forceVersion: "1.0.1",
-                optionalUpdate: "2.0.1",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .optionalUpdateRequired(.mock))
+  @Test func dataOptionalVersionRequired_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "2.0.0",
+                                    forceVersion: "1.0.1",
+                                    optionalUpdate: "2.0.1",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .optionalUpdateRequired(.mock))
   }
   
-  func testDataOptionalVersionRequired_3() async throws {
-    await tests(releaseVersion: "10.0",
-                forceVersion: "1.0.1",
-                optionalUpdate: "10.0.1",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .optionalUpdateRequired(.mock))
+  @Test func dataOptionalVersionRequired_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "10.0",
+                                    forceVersion: "1.0.1",
+                                    optionalUpdate: "10.0.1",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .optionalUpdateRequired(.mock))
   }
   
-  func testDataOptionalVersionValid_1() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "1.0.0",
-                optionalUpdate: "0.9.0",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+  @Test func dataOptionalVersionValid_1() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "1.0.0",
+                                    optionalUpdate: "0.9.0",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
   
-  func testDataOptionalVersionValid_2() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "0.0.9",
-                optionalUpdate: "0.9.2",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+  @Test func dataOptionalVersionValid_2() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.0.9",
+                                    optionalUpdate: "0.9.2",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
   
-  func testDataOptionalVersionValid_3() async throws {
-    await tests(releaseVersion: "1.0.0",
-                forceVersion: "0.1",
-                optionalUpdate: "0.5.1",
-                blackListVersions: [],
-                notice: nil,
-                isEqualStatus: .valid)
+  @Test func dataOptionalVersionValid_3() async throws {
+    try await expectAppUpdateStatus(releaseVersion: "1.0.0",
+                                    forceVersion: "0.1",
+                                    optionalUpdate: "0.5.1",
+                                    blackListVersions: [],
+                                    notice: nil,
+                                    isEqualStatus: .valid)
   }
 }

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -5,12 +5,14 @@
 //  Created by SwiftMan on 2023/02/10.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import LaunchingService
 
+@Suite("RemoteConfigParser")
 @MainActor
-final class RemoteConfigParserTests: XCTestCase {
-  func testForceUpdateParserKeepsAlertInfoWhenForceVersionIsMissing() {
+struct RemoteConfigParserTests {
+  @Test func forceUpdateParserKeepsAlertInfoWhenForceVersionIsMissing() {
     let parser = RemoteConfigForceUpdateParser(
       keyStore: RemoteConfigRegisterdKeys(),
       valueProvider: RemoteConfigClientMock(strings: [
@@ -22,13 +24,13 @@ final class RemoteConfigParserTests: XCTestCase {
 
     let appUpdateInfo = parser.parseAppUpdateInfo()
 
-    XCTAssertEqual(appUpdateInfo.version, "")
-    XCTAssertEqual(appUpdateInfo.alertTitle, "Force update")
-    XCTAssertEqual(appUpdateInfo.alertMessage, "Please update")
-    XCTAssertEqual(appUpdateInfo.alertDoneLinkURL, URL(string: "https://example.com/force")!)
+    #expect(appUpdateInfo.version == "")
+    #expect(appUpdateInfo.alertTitle == "Force update")
+    #expect(appUpdateInfo.alertMessage == "Please update")
+    #expect(appUpdateInfo.alertDoneLinkURL == URL(string: "https://example.com/force")!)
   }
 
-  func testForceUpdateParserReturnsInactiveInfoWhenDoneURLIsMissing() {
+  @Test func forceUpdateParserReturnsInactiveInfoWhenDoneURLIsMissing() {
     let parser = RemoteConfigForceUpdateParser(
       keyStore: RemoteConfigRegisterdKeys(),
       valueProvider: RemoteConfigClientMock(strings: [
@@ -40,11 +42,11 @@ final class RemoteConfigParserTests: XCTestCase {
 
     let appUpdateInfo = parser.parseAppUpdateInfo()
 
-    XCTAssertEqual(appUpdateInfo.version, "")
-    XCTAssertEqual(appUpdateInfo.alertDoneLinkURL, URL(string: "about:blank")!)
+    #expect(appUpdateInfo.version == "")
+    #expect(appUpdateInfo.alertDoneLinkURL == URL(string: "about:blank")!)
   }
 
-  func testForceUpdateParserDisablesBlackListVersionsWhenDoneURLIsMissing() {
+  @Test func forceUpdateParserDisablesBlackListVersionsWhenDoneURLIsMissing() {
     let parser = RemoteConfigForceUpdateParser(
       keyStore: RemoteConfigRegisterdKeys(),
       valueProvider: RemoteConfigClientMock(strings: [
@@ -52,10 +54,10 @@ final class RemoteConfigParserTests: XCTestCase {
       ])
     )
 
-    XCTAssertEqual(parser.parseBlackListVersions(), [])
+    #expect(parser.parseBlackListVersions() == [])
   }
 
-  func testRemoteConfigParserUsesInjectedValuesWithoutFirebase() {
+  @Test func remoteConfigParserUsesInjectedValuesWithoutFirebase() {
     let parser = RemoteConfigParser(
       valueProvider: RemoteConfigClientMock(strings: [
         "forceUpdateAppVersionKey": "2.0.0",
@@ -72,15 +74,15 @@ final class RemoteConfigParserTests: XCTestCase {
 
     let launching = parser.parse()
 
-    XCTAssertEqual(launching.forceUpdate.version, "2.0.0")
-    XCTAssertEqual(launching.forceUpdate.alertTitle, "Force update")
-    XCTAssertEqual(launching.forceUpdate.alertDoneLinkURL, URL(string: "https://example.com/force")!)
-    XCTAssertEqual(launching.optionalUpdate.version, "1.5.0")
-    XCTAssertEqual(launching.blackListVersions, ["1.0.0", "1.1.0"])
-    XCTAssertNil(launching.notice)
+    #expect(launching.forceUpdate.version == "2.0.0")
+    #expect(launching.forceUpdate.alertTitle == "Force update")
+    #expect(launching.forceUpdate.alertDoneLinkURL == URL(string: "https://example.com/force")!)
+    #expect(launching.optionalUpdate.version == "1.5.0")
+    #expect(launching.blackListVersions == ["1.0.0", "1.1.0"])
+    #expect(launching.notice == nil)
   }
 
-  func testFetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
+  @Test func fetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [
         "optionalUpdateAppVersionKey": "2.0.0",
@@ -97,9 +99,8 @@ final class RemoteConfigParserTests: XCTestCase {
 
     let status = try await service.fetchAppUpdateStatus()
 
-    XCTAssertEqual(
-      status,
-      .optionalUpdateRequired(
+    #expect(
+      status == .optionalUpdateRequired(
         UpdateAlert(title: "Optional update",
                     message: "A new version is available",
                     alertDoneLinkURL: URL(string: "https://example.com/optional")!)
@@ -107,7 +108,7 @@ final class RemoteConfigParserTests: XCTestCase {
     )
   }
 
-  func testFetchAppUpdateStatusDoesNotForceUpdateFromBlackListWhenForceURLIsMissing() async throws {
+  @Test func fetchAppUpdateStatusDoesNotForceUpdateFromBlackListWhenForceURLIsMissing() async throws {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [
         "blackListVersionsKey": "1.0.0"
@@ -120,7 +121,7 @@ final class RemoteConfigParserTests: XCTestCase {
 
     let status = try await service.fetchAppUpdateStatus()
 
-    XCTAssertEqual(status, .valid)
+    #expect(status == .valid)
   }
 }
 


### PR DESCRIPTION
## 작업 내용
- XCTestCase 상속 기반 테스트를 Swift Testing의 @Suite/@Test 구조로 전환했습니다.
- 기존 상속 테스트에서 공유하던 검증 로직은 expectAppUpdateStatus helper로 분리해 테스트 간 mutable state를 제거했습니다.
- Swift Testing 사용을 위해 Package.swift의 swift-tools-version을 6.0으로 상향했습니다.
- Swift 6 동시성 검사에서 non-Sendable static 공유로 실패하던 ISO8601DateFormatter 캐시를 제거하고 호출 단위 formatter 생성으로 변경했습니다.

## 최소 지원 버전 검토
- Swift Testing 사용을 위해 Swift tools 최소 버전을 6.0으로 올렸습니다.
- iOS/macOS/tvOS/watchOS deployment target은 테스트와 빌드에서 추가 상향이 필요하지 않아 기존 값을 유지했습니다.

## 검증
- swift build
- swift test: Swift Testing 6개 suite, 34개 테스트 통과
- ./GeneratingDocumentationSite
- git diff --check