### PR TITLE
chore. ISO8601 날짜 파싱 방식 개선

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let package = Package(
   platforms: [
     .iOS(.v15),
     .macOS(.v12),
-    .tvOS(.v13),
-    .watchOS(.v6),
+    .tvOS(.v15),
+    .watchOS(.v8),
   ],
   products: [
     .library(

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![Badge](https://img.shields.io/badge/swift-white.svg?style=flat-square&logo=Swift)
 ![Badge](https://img.shields.io/badge/SwiftUI-001b87.svg?style=flat-square&logo=Swift&logoColor=black)
-![Badge - Version](https://img.shields.io/badge/Version-0.9.0-1177AA?style=flat-square)
+![Badge - Version](https://img.shields.io/badge/Version-0.9.1-1177AA?style=flat-square)
 ![Badge - Swift Package Manager](https://img.shields.io/badge/SPM-compatible-orange?style=flat-square)
-![Badge - Platform](https://img.shields.io/badge/platform-mac_12|ios_15-yellow?style=flat-square)
+![Badge - Platform](https://img.shields.io/badge/platform-mac_12|ios_15|tvos_15|watchos_8-yellow?style=flat-square)
 ![Badge - License](https://img.shields.io/badge/license-MIT-black?style=flat-square)  
 
 ---
@@ -148,6 +148,6 @@ Once you have your Swift package set up, adding LaunchingService as a dependency
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/swift-man/LaunchingService.git", from: "0.9.0")
+    .package(url: "https://github.com/swift-man/LaunchingService.git", from: "0.9.1")
 ]
 ```

--- a/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
@@ -74,9 +74,6 @@ final class RemoteConfigNoticeParser: Sendable {
   }
 
   private static func date(from string: String) -> Date? {
-    let dateFormatter = ISO8601DateFormatter()
-    dateFormatter.formatOptions = [.withInternetDateTime]
-
-    return dateFormatter.date(from: string)
+    try? Date.ISO8601FormatStyle().parse(string)
   }
 }

--- a/Sources/LaunchingService/Public/AppUpdateStatus.swift
+++ b/Sources/LaunchingService/Public/AppUpdateStatus.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Result types App Update Status
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public enum AppUpdateStatus: Equatable, Sendable {
   /// 유효
   case valid
@@ -30,7 +30,7 @@ public enum AppUpdateStatus: Equatable, Sendable {
 }
 
 /// 업데이트 메시지
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public struct UpdateAlert: Sendable, Equatable {
   /// title: 업데이트 타이틀
   public let title: String
@@ -57,7 +57,7 @@ public struct UpdateAlert: Sendable, Equatable {
 }
 
 /// 공지 얼럿 정보
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public struct NoticeAlert: Sendable, Equatable {
   /// alert title: 얼럿 타이틀
   public let title: String

--- a/Sources/LaunchingService/Public/Launching.swift
+++ b/Sources/LaunchingService/Public/Launching.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public struct Launching: Sendable {
   public let forceUpdate: AppUpdateInfo
   public let optionalUpdate: AppUpdateInfo
@@ -26,7 +26,7 @@ public struct Launching: Sendable {
   }
 }
 
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public struct AppUpdateInfo: Sendable {
   public let version: String
   public let alertTitle: String
@@ -45,7 +45,7 @@ public struct AppUpdateInfo: Sendable {
 }
 
 /// 공지 얼럿 정보
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public struct NoticeInfo: Sendable, Equatable {
   /// alert title: 얼럿 타이틀
   public let title: String

--- a/Sources/LaunchingService/Public/LaunchingInteractable.swift
+++ b/Sources/LaunchingService/Public/LaunchingInteractable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public protocol LaunchingInteractable: AnyObject, Sendable {
   /// Firebase - RemoteConfig 의 값을 가져오고 계산 된 앱의 상태를 반환 합니다.
   ///
@@ -17,7 +17,7 @@ public protocol LaunchingInteractable: AnyObject, Sendable {
 }
 
 extension LaunchingInteractable {
-  @available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+  @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
   public func compare(releaseVersion: String, launching: Launching) -> AppUpdateStatus {
     var appStatus = AppUpdateStatusChecker().compare(releaseVersion: releaseVersion,
                                                      launching: launching)

--- a/Sources/LaunchingService/Public/LaunchingService.swift
+++ b/Sources/LaunchingService/Public/LaunchingService.swift
@@ -6,7 +6,7 @@
 //
 
 /// 앱을 구성하기 전 외부로 부터 설정을 가져와 앱 상태를 반환하는 서비스 입니다.
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public final class LaunchingService: LaunchingInteractable, Sendable {
   private let remoteConfigClient: any RemoteConfigClient
   private let appVersionProvider: any AppReleaseVersionProviding

--- a/Sources/LaunchingService/Public/LaunchingServiceError.swift
+++ b/Sources/LaunchingService/Public/LaunchingServiceError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Error types when `Not found` / `invalid` typed RemoteConfig Keys
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public enum LaunchingServiceError: Error, Equatable, Sendable {
   
   /// Invalid LinkURLValue to nil.

--- a/Sources/LaunchingService/Public/MainBundle.swift
+++ b/Sources/LaunchingService/Public/MainBundle.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public class MainBundle {
   public var releaseVersionNumber: String? {
     return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String

--- a/Sources/LaunchingService/Public/RemoteConfigRegisterdKeys.swift
+++ b/Sources/LaunchingService/Public/RemoteConfigRegisterdKeys.swift
@@ -9,10 +9,10 @@ import Foundation
 import Dependencies
 
 /// Firebase RemoteConfig 의 alignment 를 설정 합니다.
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 public struct RemoteConfigRegisterdKeys: Sendable {
   
-  @available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+  @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
   public struct ForceUpdateKeys: Sendable {
     let appVersionKey: String
     let alertTitleKey: String
@@ -40,7 +40,7 @@ public struct RemoteConfigRegisterdKeys: Sendable {
     }
   }
   
-  @available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+  @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
   public struct OptionalUpdateKeys: Sendable {
     let appVersionKey: String
     let alertTitleKey: String
@@ -64,7 +64,7 @@ public struct RemoteConfigRegisterdKeys: Sendable {
     }
   }
   
-  @available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+  @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
   public struct NoticeKeys: Sendable {
     let alertTitleKey: String
     let alertMessageKey: String
@@ -114,14 +114,14 @@ public struct RemoteConfigRegisterdKeys: Sendable {
   }
 }
 
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 extension RemoteConfigRegisterdKeys: TestDependencyKey {
   public static var testValue: RemoteConfigRegisterdKeys {
     RemoteConfigRegisterdKeys()
   }
 }
 
-@available(iOS 15.0, macOS 12, tvOS 13, watchOS 6.0, *)
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 extension DependencyValues {
   public var remoteConfigRegisterdKeys: RemoteConfigRegisterdKeys {
     get { self[RemoteConfigRegisterdKeys.self] }

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -82,6 +82,33 @@ struct RemoteConfigParserTests {
     #expect(launching.notice == nil)
   }
 
+  @Test func remoteConfigParserParsesNoticeDatesWithISO8601FormatStyle() {
+    let iso8601Style = Date.ISO8601FormatStyle()
+    let doneURL = URL(string: "https://example.com/notice")!
+    let parser = RemoteConfigParser(
+      valueProvider: RemoteConfigClientMock(
+        strings: [
+          "noticeAlertTitleKey": "Notice",
+          "noticeAlertMessageKey": "Scheduled maintenance",
+          "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(-5000)),
+          "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(5000)),
+          "noticeAlertDoneURLKey": doneURL.absoluteString
+        ],
+        bools: [
+          "noticeAlertDismissedTerminateKey": true
+        ]
+      )
+    )
+
+    let notice = parser.parse().notice
+
+    #expect(notice?.title == "Notice")
+    #expect(notice?.message == "Scheduled maintenance")
+    #expect(notice?.isAppTerminated == true)
+    #expect(notice?.doneURL == doneURL)
+    #expect(notice?.dateRange.contains(Date()) == true)
+  }
+
   @Test func fetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -109,6 +109,27 @@ struct RemoteConfigParserTests {
     #expect(notice?.dateRange.contains(Date()) == true)
   }
 
+  @Test func remoteConfigParserContinuesToParseNoticeDatesWithCompactTimeZone() {
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+
+    let parser = RemoteConfigParser(
+      valueProvider: RemoteConfigClientMock(strings: [
+        "noticeAlertTitleKey": "Notice",
+        "noticeAlertMessageKey": "Scheduled maintenance",
+        "noticeStartDateKey": dateFormatter.string(from: Date().addingTimeInterval(-5000)),
+        "noticeEndDateKey": dateFormatter.string(from: Date().addingTimeInterval(5000))
+      ])
+    )
+
+    let notice = parser.parse().notice
+
+    #expect(notice?.title == "Notice")
+    #expect(notice?.dateRange.contains(Date()) == true)
+  }
+
   @Test func fetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [


### PR DESCRIPTION
## 작업 내용
- `RemoteConfigNoticeParser`의 공지 날짜 파싱을 `ISO8601DateFormatter` 생성 방식에서 `Date.ISO8601FormatStyle().parse(_:)` 기반으로 변경했습니다.
- `Date.ISO8601FormatStyle` availability에 맞춰 `Package.swift`의 최소 지원 버전을 `tvOS 15`, `watchOS 8`로 상향했습니다.
- public API의 `@available` 선언도 `tvOS 15`, `watchOS 8`로 정리해 패키지 지원 범위와 문서가 어긋나지 않도록 했습니다.
- RemoteConfigParser 경로에서 ISO8601 공지 날짜를 파싱하는 Swift Testing 테스트를 추가했습니다.
- 기존 RemoteConfig 값 호환성 확인을 위해 `+0000` compact timezone 공지 날짜 파싱 테스트도 추가했습니다.
- `0.9.1` 배포를 위해 README 버전 배지와 Swift Package Manager 설치 예시를 업데이트했습니다.

## 참고
- 요청의 `tvOS 13/watchOS 6으로 상향`은 현재 값과 동일하고, 해당 버전에서는 `Date.ISO8601FormatStyle` 적용이 맞지 않아 실제 availability에 맞춰 `tvOS 15/watchOS 8`로 처리했습니다.
- Swift tools version은 `6.0` 기준을 유지합니다.

## 검증
- `swift build`
- `swift test` Swift Testing 6 suites, 36 tests 통과
- `./GeneratingDocumentationSite`
- `git diff --check`
