### PR TITLE
chore. swift-dependencies 최소 버전 1.4.0으로 업데이트

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "3cf50389efbf67e5573cdcf4b288d60884924a7713097a6bedd9b7c889b92ea1",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -131,8 +132,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -140,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "8282b0c59662eb38946afe30eb403663fc2ecf76",
-        "version" : "0.1.4"
+        "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
+        "version" : "1.11.0"
       }
     },
     {
@@ -163,14 +173,23 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
-        "version" : "0.8.1"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "12.13.0"),
-    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.4"),
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", "1.4.0"..<"1.12.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Badge](https://img.shields.io/badge/swift-white.svg?style=flat-square&logo=Swift)
 ![Badge](https://img.shields.io/badge/SwiftUI-001b87.svg?style=flat-square&logo=Swift&logoColor=black)
-![Badge - Version](https://img.shields.io/badge/Version-0.9.1-1177AA?style=flat-square)
+![Badge - Version](https://img.shields.io/badge/Version-0.9.2-1177AA?style=flat-square)
 ![Badge - Swift Package Manager](https://img.shields.io/badge/SPM-compatible-orange?style=flat-square)
 ![Badge - Platform](https://img.shields.io/badge/platform-mac_12|ios_15|tvos_15|watchos_8-yellow?style=flat-square)
 ![Badge - License](https://img.shields.io/badge/license-MIT-black?style=flat-square)  
@@ -148,6 +148,6 @@ Once you have your Swift package set up, adding LaunchingService as a dependency
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/swift-man/LaunchingService.git", from: "0.9.1")
+    .package(url: "https://github.com/swift-man/LaunchingService.git", from: "0.9.2")
 ]
 ```


### PR DESCRIPTION
## 작업 내용
- `swift-dependencies` 요구 조건을 `from: "0.1.4"`에서 `"1.4.0"..<"1.12.0"` 범위로 상향했습니다.
- `Package.resolved`를 갱신해 이 저장소의 검증 기준을 `swift-dependencies 1.11.0`으로 업데이트했습니다.
- `0.9.2` 배포를 위해 README 버전 배지와 Swift Package Manager 설치 예시를 업데이트했습니다.
- 전이 의존성도 새 `swift-dependencies` 범위 기준으로 함께 갱신했습니다.
  - `combine-schedulers 1.2.0`
  - `swift-clocks 1.0.6`
  - `swift-concurrency-extras 1.3.2`
  - `swift-syntax 600.0.1`
  - `xctest-dynamic-overlay 1.9.0`

## 참고
- `"1.4.0"..<"1.12.0"`는 `>= 1.4.0` 조건을 만족하면서, 현재 toolchain에서 확인된 `1.12.0` resolver 오류를 피하기 위한 상한입니다.
- 처음에는 `from: "1.4.0"`로 시도했지만, 소비 앱에서는 이 저장소의 `Package.resolved`가 적용되지 않아 `1.12.0`까지 올라갈 수 있다는 리뷰 지적을 반영했습니다.

## 검증
- `swift build`
- `swift test` Swift Testing 6 suites, 36 tests 통과
- `./GeneratingDocumentationSite`
- `git diff --check`
