### PR TITLE
docs. RemoteConfig 필수 설정 값 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ public enum LaunchingServiceError: Error {
 
 상태 판정 우선순위는 Force update, Blacklist force update, Optional update, Notice, `AppUpdateStatus.valid` 순서입니다. 특정 기능의 활성 조건이 만족되지 않으면 다음 조건으로 넘어가며, 모든 기능이 비활성 상태일 때 `valid`가 반환됩니다.
 
+Force update와 Optional update의 버전 비교는 단순 문자열 비교가 아니라 `String.compare(_:options: .numeric)` 기반입니다. 버전 component 수가 다르면 부족한 쪽에 `0`을 채운 뒤 비교하므로 `1.10.0`은 `1.2.0`보다 높은 버전으로 판단됩니다.
+
 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 
 ### Required Values by Feature

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ public enum LaunchingServiceError: Error {
 - Notice는 `noticeStartDateKey`와 `noticeEndDateKey`가 활성 조건입니다.
 - 활성 조건 값 중 URL 또는 날짜가 파싱되지 않으면 해당 기능은 비활성 상태로 판단됩니다.
 - 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
-- Bool 값이 없으면 `false`로 처리됩니다.
+- `noticeAlertDismissedTerminateKey` 같은 Bool 설정이 없으면 `false`로 처리됩니다.
 
 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 
@@ -107,6 +107,8 @@ public enum LaunchingServiceError: Error {
 `forceUpdateAlertDoneLinkURLKey`는 강제 업데이트 버전 체크와 블랙리스트 체크에 공통으로 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `forceUpdateAppVersionKey`, `blackListVersionsKey` 값이 있어도 강제 업데이트와 블랙리스트 체크가 비활성화됩니다.
 
 `noticeAlertDoneURLKey`는 공지 노출 조건이 아닙니다. 이 값이 없거나 URL로 파싱되지 않으면 공지는 계속 노출될 수 있고, `doneURL`만 제공되지 않습니다.
+
+`LaunchingService`는 이 경우 UI 버튼 표시 여부를 결정하지 않고 `NoticeAlert.doneURL`에 `nil`을 전달합니다. 버튼 숨김, 비활성화, 링크 없는 확인 동작은 presentation layer에서 결정합니다.
 
 ### Default Key Names
 | Group | Key | Value type |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ public enum LaunchingServiceError: Error {
 
 `forceUpdateAlertDoneLinkURLKey`는 강제 업데이트 버전 체크와 블랙리스트 체크에 공통으로 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `forceUpdateAppVersionKey`, `blackListVersionsKey` 값이 있어도 강제 업데이트와 블랙리스트 체크가 비활성화됩니다.
 
+`noticeAlertDoneURLKey`는 공지 노출 조건이 아닙니다. 이 값이 없거나 URL로 파싱되지 않으면 공지는 계속 노출될 수 있고, `doneURL`만 제공되지 않습니다.
+
 ### Default Key Names
 | Group | Key | Value type |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ public enum LaunchingServiceError: Error {
 ## Firebase Remote Config Values
 `RemoteConfigRegisterdKeys`는 Firebase Remote Config에서 읽을 키 이름을 정의합니다. 기본 initializer를 사용한다면 Firebase Remote Config에 아래 기본 키 이름으로 값을 등록해야 합니다.
 
-버전, URL, 날짜처럼 기능 활성화 조건에 쓰이는 문자열 값이 없거나 공백이면 해당 기능은 비활성 상태로 판단됩니다. 반면 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다. Bool 값이 없으면 `false`로 처리됩니다.
+값이 없거나 공백인 경우의 동작은 키의 역할에 따라 다릅니다.
+
+- 버전, 필수 URL, 날짜 조건 값이 없으면 해당 기능은 비활성 상태로 판단됩니다.
+- 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
+- Bool 값이 없으면 `false`로 처리됩니다.
 
 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ public enum LaunchingServiceError: Error {
 ## Firebase Remote Config Values
 `RemoteConfigRegisterdKeys`는 Firebase Remote Config에서 읽을 키 이름을 정의합니다. 기본 initializer를 사용한다면 Firebase Remote Config에 아래 기본 키 이름으로 값을 등록해야 합니다.
 
-문자열 값이 없거나 공백이면 비활성 값으로 처리되고, Bool 값이 없으면 `false`로 처리됩니다. 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
+버전, URL, 날짜처럼 기능 활성화 조건에 쓰이는 문자열 값이 없거나 공백이면 해당 기능은 비활성 상태로 판단됩니다. 반면 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다. Bool 값이 없으면 `false`로 처리됩니다.
+
+타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 
 ### Required Values by Feature
 | Feature | Required values | Recommended / optional values |

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ public enum LaunchingServiceError: Error {
 - Blacklist force update는 `forceUpdateAlertDoneLinkURLKey`와 `blackListVersionsKey`가 활성 조건입니다.
 - Optional update는 `optionalUpdateAppVersionKey`와 `optionalUpdateAlertDoneLinkURLKey`가 활성 조건입니다.
 - Notice는 `noticeStartDateKey`와 `noticeEndDateKey`가 활성 조건입니다.
-- Force update, Blacklist force update, Optional update의 필수 URL이 파싱되지 않으면 해당 기능은 비활성 상태로 판단됩니다.
-- Notice의 시작일 또는 종료일이 ISO8601 날짜로 파싱되지 않으면 Notice는 비활성 상태로 판단됩니다.
+- Force update와 Blacklist force update의 `forceUpdateAlertDoneLinkURLKey`, Optional update의 `optionalUpdateAlertDoneLinkURLKey`가 URL로 파싱되지 않으면 해당 기능은 비활성 상태로 판단됩니다.
+- Notice의 시작일 또는 종료일이 ISO8601 날짜로 파싱되지 않거나, 시작일이 종료일보다 같거나 늦으면 Notice는 비활성 상태로 판단됩니다.
 - Notice의 `noticeAlertDoneURLKey`는 예외적으로 활성 조건이 아니며, 파싱되지 않아도 Notice는 계속 노출될 수 있고 `doneURL`만 제공되지 않습니다.
 - 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
 - `noticeAlertDismissedTerminateKey` 같은 Bool 설정이 없으면 `false`로 처리됩니다.
@@ -111,6 +111,8 @@ public enum LaunchingServiceError: Error {
 | Notice | `noticeStartDateKey`: ISO8601 시작일<br>`noticeEndDateKey`: ISO8601 종료일 | 시작일이 종료일보다 빠르고, 현재 시간이 기간 안에 있음 | `noticeAlertTitleKey`<br>`noticeAlertMessageKey`<br>`noticeAlertDoneURLKey`<br>`noticeAlertDismissedTerminateKey` |
 
 `forceUpdateAlertDoneLinkURLKey`는 강제 업데이트 버전 체크와 블랙리스트 체크에 공통으로 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `forceUpdateAppVersionKey`, `blackListVersionsKey` 값이 있어도 강제 업데이트와 블랙리스트 체크가 비활성화됩니다.
+
+`optionalUpdateAlertDoneLinkURLKey`는 선택 업데이트에 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `optionalUpdateAppVersionKey` 값이 있어도 선택 업데이트 체크가 비활성화됩니다.
 
 `LaunchingService`는 `noticeAlertDoneURLKey`가 없거나 파싱되지 않은 경우 UI 버튼 표시 여부를 결정하지 않고 `NoticeAlert.doneURL`에 `nil`을 전달합니다. 버튼 숨김, 비활성화, 링크 없는 확인 동작은 presentation layer에서 결정합니다.
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ import Dependencies
 
 extension RemoteConfigRegisterdKeys: DependencyKey {
   public static var liveValue = RemoteConfigRegisterdKeys(
-    forceUpdateKeys: #...#
-    optionalUpdateKeys: #...#
-    noticeKeys : #...#
+    forceUpdateKeys: #...#,
+    optionalUpdateKeys: #...#,
+    noticeKeys: #...#
   )
 }
 ```

--- a/README.md
+++ b/README.md
@@ -175,14 +175,45 @@ noticeAlertDismissedTerminateKey = false
 ```
 
 ### Your Custom Remote Config Keys
+
+기본 키 이름을 그대로 사용한다면 별도 값 없이 기본 initializer를 사용할 수 있습니다.
+
+```swift
+import Dependencies
+
+extension RemoteConfigRegisterdKeys: DependencyKey {
+  public static var liveValue = RemoteConfigRegisterdKeys()
+}
+```
+
+Remote Config 키 이름을 앱별로 바꾸려면 각 key group에 실제 문자열 키를 전달합니다.
+
 ```swift
 import Dependencies
 
 extension RemoteConfigRegisterdKeys: DependencyKey {
   public static var liveValue = RemoteConfigRegisterdKeys(
-    forceUpdateKeys: #...#,
-    optionalUpdateKeys: #...#,
-    noticeKeys: #...#
+    forceUpdateKeys: .init(
+      appVersionKey: "launching_force_update_version",
+      alertTitleKey: "launching_force_update_title",
+      alertMessageKey: "launching_force_update_message",
+      alertDoneLinkURLKey: "launching_force_update_done_url",
+      blackListVersionsKey: "launching_blacklist_versions"
+    ),
+    optionalUpdateKeys: .init(
+      appVersionKey: "launching_optional_update_version",
+      alertTitleKey: "launching_optional_update_title",
+      alertMessageKey: "launching_optional_update_message",
+      alertDoneLinkURLKey: "launching_optional_update_done_url"
+    ),
+    noticeKeys: .init(
+      alertTitleKey: "launching_notice_title",
+      alertMessageKey: "launching_notice_message",
+      startDateKey: "launching_notice_start_date",
+      endDateKey: "launching_notice_end_date",
+      alertDoneURLKey: "launching_notice_done_url",
+      alertDismissedTerminateKey: "launching_notice_dismissed_terminate"
+    )
   )
 }
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ public enum LaunchingServiceError: Error {
 - Blacklist force update는 `forceUpdateAlertDoneLinkURLKey`와 `blackListVersionsKey`가 활성 조건입니다.
 - Optional update는 `optionalUpdateAppVersionKey`와 `optionalUpdateAlertDoneLinkURLKey`가 활성 조건입니다.
 - Notice는 `noticeStartDateKey`와 `noticeEndDateKey`가 활성 조건입니다.
-- 활성 조건 값 중 URL 또는 날짜가 파싱되지 않으면 해당 기능은 비활성 상태로 판단됩니다.
+- Force update, Blacklist force update, Optional update의 필수 URL이 파싱되지 않으면 해당 기능은 비활성 상태로 판단됩니다.
+- Notice의 시작일 또는 종료일이 ISO8601 날짜로 파싱되지 않으면 Notice는 비활성 상태로 판단됩니다.
+- Notice의 `noticeAlertDoneURLKey`는 예외적으로 활성 조건이 아니며, 파싱되지 않아도 Notice는 계속 노출될 수 있고 `doneURL`만 제공되지 않습니다.
 - 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
 - `noticeAlertDismissedTerminateKey` 같은 Bool 설정이 없으면 `false`로 처리됩니다.
 
@@ -106,9 +108,7 @@ public enum LaunchingServiceError: Error {
 
 `forceUpdateAlertDoneLinkURLKey`는 강제 업데이트 버전 체크와 블랙리스트 체크에 공통으로 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `forceUpdateAppVersionKey`, `blackListVersionsKey` 값이 있어도 강제 업데이트와 블랙리스트 체크가 비활성화됩니다.
 
-`noticeAlertDoneURLKey`는 공지 노출 조건이 아닙니다. 이 값이 없거나 URL로 파싱되지 않으면 공지는 계속 노출될 수 있고, `doneURL`만 제공되지 않습니다.
-
-`LaunchingService`는 이 경우 UI 버튼 표시 여부를 결정하지 않고 `NoticeAlert.doneURL`에 `nil`을 전달합니다. 버튼 숨김, 비활성화, 링크 없는 확인 동작은 presentation layer에서 결정합니다.
+`LaunchingService`는 `noticeAlertDoneURLKey`가 없거나 파싱되지 않은 경우 UI 버튼 표시 여부를 결정하지 않고 `NoticeAlert.doneURL`에 `nil`을 전달합니다. 버튼 숨김, 비활성화, 링크 없는 확인 동작은 presentation layer에서 결정합니다.
 
 ### Default Key Names
 | Group | Key | Value type |

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ If the app is a blacklisted version, it is force updated. `blackListVersionsKey`
 
 ## Notice
 ### DateFormat
-Notice dates are parsed with `Date.ISO8601FormatStyle()`. The notice is shown only when both dates are valid, `noticeStartDateKey` is earlier than `noticeEndDateKey`, and the current time is inside that range.
-UTC `Z` strings are recommended for consistent operations, and ISO8601 strings with timezone offsets are accepted when `Date.ISO8601FormatStyle()` can parse them.
+공지 날짜는 `Date.ISO8601FormatStyle()`로 파싱됩니다. 두 날짜가 모두 유효하고, `noticeStartDateKey`가 `noticeEndDateKey`보다 빠르며, 현재 시간이 기간 안에 있을 때만 공지가 노출됩니다.
+운영 일관성을 위해 UTC `Z` 문자열을 권장합니다. `Date.ISO8601FormatStyle()`로 파싱 가능한 timezone offset이 포함된 ISO8601 문자열도 사용할 수 있습니다.
 
 ```
 2026-06-24T00:00:00Z

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ public enum LaunchingServiceError: Error {
 ## Firebase Remote Config Values
 `RemoteConfigRegisterdKeys`는 Firebase Remote Config에서 읽을 키 이름을 정의합니다. 기본 initializer를 사용한다면 Firebase Remote Config에 아래 기본 키 이름으로 값을 등록해야 합니다.
 
+`fetchAppUpdateStatus()`는 Firebase Remote Config의 `fetchAndActivate()`가 실패해도 현재 활성값 또는 기본값을 기준으로 앱 상태 파싱을 계속 진행합니다.
+
 값이 없거나 공백인 경우의 동작은 키의 역할에 따라 다릅니다.
 
 - Force update는 `forceUpdateAlertDoneLinkURLKey`와 `forceUpdateAppVersionKey`가 활성 조건입니다.

--- a/README.md
+++ b/README.md
@@ -81,17 +81,77 @@ public enum LaunchingServiceError: Error {
 }
 ```
 
-## Default Keys
-![Image](https://drive.google.com/uc?export=view&id=1f2dRMrS9SuRiVWXolqrGLXiCvrpgcVQd)  
+## Firebase Remote Config Values
+`RemoteConfigRegisterdKeys`는 Firebase Remote Config에서 읽을 키 이름을 정의합니다. 기본 initializer를 사용한다면 Firebase Remote Config에 아래 기본 키 이름으로 값을 등록해야 합니다.
 
-```swift
-"forceUpdateAlertDoneLinkURLKey"
-"forceUpdateAppVersionKey" // (Optional Value)
-"forceUpdateMessageKey" // (Optional Key, Value)
-"optionalUpdateAppVersionKey" // (Optional Key, Value)
-"optionalUpdateMessageKey" // (Optional Value)
-"blackListVersionsKey" // (Optional Key, Value)
-...
+문자열 값이 없거나 공백이면 비활성 값으로 처리되고, Bool 값이 없으면 `false`로 처리됩니다. 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
+
+### Required Values by Feature
+| Feature | Required values | Recommended / optional values |
+| --- | --- | --- |
+| Force update | `forceUpdateAlertDoneLinkURLKey`: 유효한 URL<br>`forceUpdateAppVersionKey`: 현재 앱 버전보다 높은 강제 업데이트 버전 | `forceUpdateAlertTitleKey`<br>`forceUpdateAlertMessageKey` |
+| Blacklist force update | `forceUpdateAlertDoneLinkURLKey`: 유효한 URL<br>`blackListVersionsKey`: 현재 앱 버전을 포함한 comma-separated 버전 목록 | `forceUpdateAlertTitleKey`<br>`forceUpdateAlertMessageKey` |
+| Optional update | `optionalUpdateAppVersionKey`: 현재 앱 버전보다 높은 선택 업데이트 버전<br>`optionalUpdateAlertDoneLinkURLKey`: 유효한 URL | `optionalUpdateAlertTitleKey`<br>`optionalUpdateAlertMessageKey` |
+| Notice | `noticeStartDateKey`: ISO8601 시작일<br>`noticeEndDateKey`: ISO8601 종료일<br>시작일이 종료일보다 빠르고, 현재 시간이 기간 안에 있어야 함 | `noticeAlertTitleKey`<br>`noticeAlertMessageKey`<br>`noticeAlertDoneURLKey`<br>`noticeAlertDismissedTerminateKey` |
+
+`forceUpdateAlertDoneLinkURLKey`는 강제 업데이트 버전 체크와 블랙리스트 체크에 공통으로 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `forceUpdateAppVersionKey`, `blackListVersionsKey` 값이 있어도 강제 업데이트와 블랙리스트 체크가 비활성화됩니다.
+
+### Default Key Names
+| Group | Key | Value type |
+| --- | --- | --- |
+| Force update | `forceUpdateAppVersionKey` | String, e.g. `2.0.0` |
+| Force update | `forceUpdateAlertTitleKey` | String |
+| Force update | `forceUpdateAlertMessageKey` | String |
+| Force update | `forceUpdateAlertDoneLinkURLKey` | String URL |
+| Force update | `blackListVersionsKey` | String, e.g. `1.0.0, 1.2.0, 2.0.0` |
+| Optional update | `optionalUpdateAppVersionKey` | String, e.g. `1.5.0` |
+| Optional update | `optionalUpdateAlertTitleKey` | String |
+| Optional update | `optionalUpdateAlertMessageKey` | String |
+| Optional update | `optionalUpdateAlertDoneLinkURLKey` | String URL |
+| Notice | `noticeAlertTitleKey` | String |
+| Notice | `noticeAlertMessageKey` | String |
+| Notice | `noticeStartDateKey` | String ISO8601 date |
+| Notice | `noticeEndDateKey` | String ISO8601 date |
+| Notice | `noticeAlertDoneURLKey` | String URL |
+| Notice | `noticeAlertDismissedTerminateKey` | Bool |
+
+### Minimal Remote Config Examples
+Force update:
+
+```text
+forceUpdateAppVersionKey = 2.0.0
+forceUpdateAlertDoneLinkURLKey = https://apps.apple.com/app/id0000000000
+forceUpdateAlertTitleKey = 업데이트가 필요합니다
+forceUpdateAlertMessageKey = 안정적인 사용을 위해 최신 버전으로 업데이트해주세요.
+```
+
+Blacklist force update:
+
+```text
+blackListVersionsKey = 1.0.0, 1.0.1
+forceUpdateAlertDoneLinkURLKey = https://apps.apple.com/app/id0000000000
+forceUpdateAlertTitleKey = 업데이트가 필요합니다
+forceUpdateAlertMessageKey = 현재 버전은 더 이상 지원하지 않습니다.
+```
+
+Optional update:
+
+```text
+optionalUpdateAppVersionKey = 1.5.0
+optionalUpdateAlertDoneLinkURLKey = https://apps.apple.com/app/id0000000000
+optionalUpdateAlertTitleKey = 새 버전이 있습니다
+optionalUpdateAlertMessageKey = 더 나은 사용성을 위해 업데이트할 수 있습니다.
+```
+
+Notice:
+
+```text
+noticeStartDateKey = 2026-06-24T00:00:00Z
+noticeEndDateKey = 2026-06-25T00:00:00Z
+noticeAlertTitleKey = 점검 안내
+noticeAlertMessageKey = 서비스 점검이 예정되어 있습니다.
+noticeAlertDoneURLKey = https://example.com/notice
+noticeAlertDismissedTerminateKey = false
 ```
 
 ### Your Custom Remote Config Keys
@@ -108,22 +168,25 @@ extension RemoteConfigRegisterdKeys: DependencyKey {
 ```
 
 ## BlackList
-If the app is a blacklisted version, it is force updated.
+If the app is a blacklisted version, it is force updated. `blackListVersionsKey` is a comma-separated string, and `forceUpdateAlertDoneLinkURLKey` must also be set to a URL value.
+
 ```
 1.0.0, 1.2.0, 2.0.0
 ```
 
 ## Notice
 ### DateFormat
+Notice dates are parsed with `Date.ISO8601FormatStyle()`. The notice is shown only when both dates are valid, `noticeStartDateKey` is earlier than `noticeEndDateKey`, and the current time is inside that range.
+
 ```
-yyyy-MM-ddTHH:mm:ssZ
+2026-06-24T00:00:00Z
 ```
 
 * noticeStartDateKey
-  * value: String (ex: 2023-02-12T02:22:40Z) // UTC
+  * value: String (ex: 2026-06-24T00:00:00Z) // UTC
   
 * noticeEndDateKey
- * value: String (ex: 2023-02-14T05:12:55Z) // UTC
+  * value: String (ex: 2026-06-25T00:00:00Z) // UTC
  
 ### Title, Message
 * noticeAlertTitleKey

--- a/README.md
+++ b/README.md
@@ -90,18 +90,19 @@ public enum LaunchingServiceError: Error {
 - Blacklist force update는 `forceUpdateAlertDoneLinkURLKey`와 `blackListVersionsKey`가 활성 조건입니다.
 - Optional update는 `optionalUpdateAppVersionKey`와 `optionalUpdateAlertDoneLinkURLKey`가 활성 조건입니다.
 - Notice는 `noticeStartDateKey`와 `noticeEndDateKey`가 활성 조건입니다.
+- 활성 조건 값 중 URL 또는 날짜가 파싱되지 않으면 해당 기능은 비활성 상태로 판단됩니다.
 - 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
 - Bool 값이 없으면 `false`로 처리됩니다.
 
 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 
 ### Required Values by Feature
-| Feature | Required values | Recommended / optional values |
-| --- | --- | --- |
-| Force update | `forceUpdateAlertDoneLinkURLKey`: 유효한 URL<br>`forceUpdateAppVersionKey`: 현재 앱 버전보다 높은 강제 업데이트 버전 | `forceUpdateAlertTitleKey`<br>`forceUpdateAlertMessageKey` |
-| Blacklist force update | `forceUpdateAlertDoneLinkURLKey`: 유효한 URL<br>`blackListVersionsKey`: 현재 앱 버전을 포함한 comma-separated 버전 목록 | `forceUpdateAlertTitleKey`<br>`forceUpdateAlertMessageKey` |
-| Optional update | `optionalUpdateAppVersionKey`: 현재 앱 버전보다 높은 선택 업데이트 버전<br>`optionalUpdateAlertDoneLinkURLKey`: 유효한 URL | `optionalUpdateAlertTitleKey`<br>`optionalUpdateAlertMessageKey` |
-| Notice | `noticeStartDateKey`: ISO8601 시작일<br>`noticeEndDateKey`: ISO8601 종료일<br>시작일이 종료일보다 빠르고, 현재 시간이 기간 안에 있어야 함 | `noticeAlertTitleKey`<br>`noticeAlertMessageKey`<br>`noticeAlertDoneURLKey`<br>`noticeAlertDismissedTerminateKey` |
+| Feature | Required values | Activation condition | Recommended / optional values |
+| --- | --- | --- | --- |
+| Force update | `forceUpdateAlertDoneLinkURLKey`: 유효한 URL<br>`forceUpdateAppVersionKey`: 강제 업데이트 버전 | `forceUpdateAppVersionKey`가 현재 앱 버전보다 높음 | `forceUpdateAlertTitleKey`<br>`forceUpdateAlertMessageKey` |
+| Blacklist force update | `forceUpdateAlertDoneLinkURLKey`: 유효한 URL<br>`blackListVersionsKey`: comma-separated 버전 목록 | `blackListVersionsKey`가 현재 앱 버전을 포함함 | `forceUpdateAlertTitleKey`<br>`forceUpdateAlertMessageKey` |
+| Optional update | `optionalUpdateAppVersionKey`: 선택 업데이트 버전<br>`optionalUpdateAlertDoneLinkURLKey`: 유효한 URL | `optionalUpdateAppVersionKey`가 현재 앱 버전보다 높음 | `optionalUpdateAlertTitleKey`<br>`optionalUpdateAlertMessageKey` |
+| Notice | `noticeStartDateKey`: ISO8601 시작일<br>`noticeEndDateKey`: ISO8601 종료일 | 시작일이 종료일보다 빠르고, 현재 시간이 기간 안에 있음 | `noticeAlertTitleKey`<br>`noticeAlertMessageKey`<br>`noticeAlertDoneURLKey`<br>`noticeAlertDismissedTerminateKey` |
 
 `forceUpdateAlertDoneLinkURLKey`는 강제 업데이트 버전 체크와 블랙리스트 체크에 공통으로 필요합니다. 이 URL 값이 없거나 유효하지 않으면 `forceUpdateAppVersionKey`, `blackListVersionsKey` 값이 있어도 강제 업데이트와 블랙리스트 체크가 비활성화됩니다.
 
@@ -124,7 +125,7 @@ public enum LaunchingServiceError: Error {
 | Notice | `noticeStartDateKey` | String ISO8601 date |
 | Notice | `noticeEndDateKey` | String ISO8601 date |
 | Notice | `noticeAlertDoneURLKey` | String URL |
-| Notice | `noticeAlertDismissedTerminateKey` | Bool |
+| Notice | `noticeAlertDismissedTerminateKey` | Bool, default `false` |
 
 ### Minimal Remote Config Examples
 Force update:

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ noticeAlertDismissedTerminateKey = false
 ```swift
 import Dependencies
 
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 extension RemoteConfigRegisterdKeys: DependencyKey {
   public static var liveValue = RemoteConfigRegisterdKeys()
 }
@@ -193,6 +194,7 @@ Remote Config 키 이름을 앱별로 바꾸려면 각 key group에 실제 문�
 ```swift
 import Dependencies
 
+@available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
 extension RemoteConfigRegisterdKeys: DependencyKey {
   public static var liveValue = RemoteConfigRegisterdKeys(
     forceUpdateKeys: .init(
@@ -220,15 +222,15 @@ extension RemoteConfigRegisterdKeys: DependencyKey {
 }
 ```
 
-## BlackList
-If the app is a blacklisted version, it is force updated. `blackListVersionsKey` is a comma-separated string, and `forceUpdateAlertDoneLinkURLKey` must also be set to a URL value.
+## 블랙리스트 업데이트
+현재 앱 버전이 블랙리스트 버전에 포함되면 강제 업데이트 상태로 판단됩니다. `blackListVersionsKey`는 comma-separated 버전 문자열이며, `forceUpdateAlertDoneLinkURLKey`도 유효한 URL 값으로 설정되어 있어야 합니다.
 
 ```
 1.0.0, 1.2.0, 2.0.0
 ```
 
-## Notice
-### DateFormat
+## 공지사항
+### 날짜 형식
 공지 날짜는 `Date.ISO8601FormatStyle()`로 파싱됩니다. 두 날짜가 모두 유효하고, `noticeStartDateKey`가 `noticeEndDateKey`보다 빠르며, 현재 시간이 기간 안에 있을 때만 공지가 노출됩니다.
 운영 일관성을 위해 UTC `Z` 문자열을 권장합니다. `Date.ISO8601FormatStyle()`로 파싱 가능한 timezone offset이 포함된 ISO8601 문자열도 사용할 수 있습니다.
 
@@ -242,26 +244,26 @@ If the app is a blacklisted version, it is force updated. `blackListVersionsKey`
 * noticeEndDateKey
   * value: String (ex: 2026-06-25T00:00:00Z) // UTC
  
-### Title, Message
+### 제목, 메시지
 * noticeAlertTitleKey
   * value: String
 * noticeAlertMessageKey
   * value: String
 
-### URL Landing
+### 공지 링크
 * noticeAlertDoneURLKey
   * value: String (ex: https://google.com)
 
-### App Terminate
+### 앱 종료
 * noticeAlertDismissedTerminateKey
   * value: Bool
 
-## Installation
+## 설치
 ### Swift Package Manager
 
-The [Swift Package Manager](https://swift.org/package-manager/) is a tool for automating the distribution of Swift code and is integrated into the `swift` compiler. 
+[Swift Package Manager](https://swift.org/package-manager/)는 Swift 코드 배포를 자동화하는 도구이며 `swift` 컴파일러에 통합되어 있습니다.
 
-Once you have your Swift package set up, adding LaunchingService as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
+Swift package 설정이 끝났다면 `Package.swift`의 `dependencies` 값에 LaunchingService를 추가해 사용할 수 있습니다.
 
 ```swift
 dependencies: [

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ public enum LaunchingServiceError: Error {
 
 값이 없거나 공백인 경우의 동작은 키의 역할에 따라 다릅니다.
 
-- 버전, 필수 URL, 날짜 조건 값이 없으면 해당 기능은 비활성 상태로 판단됩니다.
+- Force update는 `forceUpdateAlertDoneLinkURLKey`와 `forceUpdateAppVersionKey`가 활성 조건입니다.
+- Blacklist force update는 `forceUpdateAlertDoneLinkURLKey`와 `blackListVersionsKey`가 활성 조건입니다.
+- Optional update는 `optionalUpdateAppVersionKey`와 `optionalUpdateAlertDoneLinkURLKey`가 활성 조건입니다.
+- Notice는 `noticeStartDateKey`와 `noticeEndDateKey`가 활성 조건입니다.
 - 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
 - Bool 값이 없으면 `false`로 처리됩니다.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ public enum LaunchingServiceError: Error {
 - 타이틀과 메시지 문자열이 없으면 기능 트리거는 유지될 수 있고, 빈 문자열로 노출될 수 있습니다.
 - `noticeAlertDismissedTerminateKey` 같은 Bool 설정이 없으면 `false`로 처리됩니다.
 
+상태 판정 우선순위는 Force update, Blacklist force update, Optional update, Notice, `AppUpdateStatus.valid` 순서입니다. 특정 기능의 활성 조건이 만족되지 않으면 다음 조건으로 넘어가며, 모든 기능이 비활성 상태일 때 `valid`가 반환됩니다.
+
 타이틀과 메시지는 파서 기준으로는 생략할 수 있지만, 사용자에게 보여지는 얼럿 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 
 ### Required Values by Feature
@@ -193,6 +195,7 @@ If the app is a blacklisted version, it is force updated. `blackListVersionsKey`
 ## Notice
 ### DateFormat
 Notice dates are parsed with `Date.ISO8601FormatStyle()`. The notice is shown only when both dates are valid, `noticeStartDateKey` is earlier than `noticeEndDateKey`, and the current time is inside that range.
+UTC `Z` strings are recommended for consistent operations, and ISO8601 strings with timezone offsets are accepted when `Date.ISO8601FormatStyle()` can parse them.
 
 ```
 2026-06-24T00:00:00Z

--- a/Sources/LaunchingService/LaunchingService.docc/LaunchingService.md
+++ b/Sources/LaunchingService/LaunchingService.docc/LaunchingService.md
@@ -4,13 +4,67 @@ Firebase Remote Config 기반 앱 실행 상태 확인 서비스입니다.
 
 ## Overview
 
-강제 업데이트, 선택 업데이트, 블랙리스트 버전, 공지 노출 여부를 계산해 앱 시작 시 필요한 상태를 반환합니다.
+`LaunchingService`는 앱 시작 시 Firebase Remote Config 값을 읽고, 현재 앱 버전과 설정 값을 비교해 앱이 어떤 실행 상태로 진입해야 하는지 계산합니다. 서비스는 UI를 직접 표시하지 않고 ``AppUpdateStatus``만 반환합니다. 강제 업데이트 화면, 선택 업데이트 화면, 공지 얼럿 같은 실제 presentation 처리는 앱 또는 별도 UI 패키지에서 담당합니다.
+
+가장 기본적인 사용법은 앱 시작 흐름에서 ``LaunchingService/fetchAppUpdateStatus()``를 호출하고, 반환된 상태에 맞춰 화면을 분기하는 것입니다.
+
+```swift
+let service = LaunchingService()
+let status = try await service.fetchAppUpdateStatus()
+```
+
+### Runtime Flow
+
+`fetchAppUpdateStatus()`는 Firebase Remote Config의 `fetchAndActivate()`를 먼저 시도합니다. fetch가 실패해도 즉시 오류로 종료하지 않고, 현재 활성값 또는 기본값을 기준으로 상태 파싱을 계속 진행합니다. 이후 앱 버전과 Remote Config 값을 비교해 아래 우선순서로 상태를 판단합니다.
+
+1. Force update
+2. Blacklist force update
+3. Optional update
+4. Notice
+5. ``AppUpdateStatus/valid``
+
+앞선 상태가 활성화되면 뒤의 상태는 평가 결과로 노출되지 않습니다. 예를 들어 강제 업데이트가 필요한 경우 공지 조건이 맞더라도 반환 상태는 ``AppUpdateStatus/forcedUpdateRequired(_:)``입니다.
+
+### Remote Config Contract
+
+``RemoteConfigRegisterdKeys``는 Firebase Remote Config에서 읽을 키 이름을 정의합니다. 기본 키를 그대로 사용한다면 Remote Config에 다음 값들이 기능별 활성 조건으로 등록되어야 합니다.
+
+| Feature | Required values | Activation condition |
+| --- | --- | --- |
+| Force update | `forceUpdateAlertDoneLinkURLKey`, `forceUpdateAppVersionKey` | 강제 업데이트 버전이 현재 앱 버전보다 높음 |
+| Blacklist force update | `forceUpdateAlertDoneLinkURLKey`, `blackListVersionsKey` | 블랙리스트 버전 목록이 현재 앱 버전을 포함함 |
+| Optional update | `optionalUpdateAppVersionKey`, `optionalUpdateAlertDoneLinkURLKey` | 선택 업데이트 버전이 현재 앱 버전보다 높음 |
+| Notice | `noticeStartDateKey`, `noticeEndDateKey` | 현재 시간이 공지 기간 안에 있음 |
+
+업데이트 계열에서 URL 값이 없거나 URL로 파싱되지 않으면 해당 업데이트 상태는 비활성으로 판단됩니다. Notice의 시작일 또는 종료일이 ISO8601 날짜로 파싱되지 않거나, 시작일이 종료일보다 같거나 늦으면 Notice도 비활성입니다.
+
+Notice의 `noticeAlertDoneURLKey`는 공지 노출 조건이 아닙니다. 값이 없거나 URL로 파싱되지 않아도 공지는 노출될 수 있고, ``NoticeAlert/doneURL``만 `nil`로 전달됩니다. 버튼 숨김, 비활성화, 링크 없는 확인 동작은 presentation layer에서 결정합니다.
+
+타이틀과 메시지 값은 파서 기준으로 생략될 수 있지만, 값이 없으면 빈 문자열로 노출될 수 있습니다. 사용자에게 보이는 문구이므로 실제 서비스에서는 함께 설정하는 것을 권장합니다.
 
 ## Topics
 
-### Essentials
+### Service
 
 - ``LaunchingService``
 - ``LaunchingInteractable``
+
+### Status
+
 - ``AppUpdateStatus``
+- ``UpdateAlert``
+- ``NoticeAlert``
+
+### Configuration
+
 - ``RemoteConfigRegisterdKeys``
+
+### Parsed Values
+
+- ``Launching``
+- ``AppUpdateInfo``
+- ``NoticeInfo``
+
+### Errors
+
+- ``LaunchingServiceError``


### PR DESCRIPTION
## 변경 사항
- `RemoteConfigRegisterdKeys` 기본 키 이름과 Firebase Remote Config에 등록해야 하는 값의 관계를 README에 정리했습니다.
- 강제 업데이트, 블랙리스트 강제 업데이트, 선택 업데이트, 공지 기능별 활성화 필수 값을 표로 추가했습니다.
- 블랙리스트도 `forceUpdateAlertDoneLinkURLKey`가 없으면 비활성화되는 조건을 명시했습니다.
- 오래된 `forceUpdateMessageKey`, `optionalUpdateMessageKey` 예시를 실제 키 이름인 `forceUpdateAlertMessageKey`, `optionalUpdateAlertMessageKey` 기준 문서로 교체했습니다.
- Notice 날짜가 `Date.ISO8601FormatStyle()`로 파싱되고, 시작일/종료일/현재 시간 조건을 만족해야 노출된다는 점을 문서화했습니다.

## 검증
- `swift build`
- `swift test`
- `./GeneratingDocumentationSite`

## 코드리뷰 참고
- 코드 변경 없이 README 문서만 수정했습니다.
- DocC 생성 결과는 `.build/docc-site/LaunchingService`에 생성되며 커밋하지 않았습니다.
