### PR TITLE
refactor. Notice 날짜 활성 판정 책임 분리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### 변경
+
+- Notice 활성 기간의 현재 시간 판정을 `NoticeChecker`로 단일화해 `RemoteConfigNoticeParser`가 Remote Config 값 파싱과 모델 생성만 담당하도록 정리했습니다.
+
 ## [0.9.3] - 2026-07-08
 
 ### 변경

--- a/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
@@ -20,8 +20,8 @@ final class RemoteConfigNoticeParser: Sendable {
   func parseNotice() -> NoticeInfo? {
     guard
       let noticeStartDate,
-        let noticeEndDate,
-        noticeStartDate < noticeEndDate
+      let noticeEndDate,
+      noticeStartDate < noticeEndDate
     else { return nil }
     
     return NoticeInfo(title: noticeAlertTitle,

--- a/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
+++ b/Sources/LaunchingService/Private/RemoteConfigNoticeParser.swift
@@ -24,9 +24,6 @@ final class RemoteConfigNoticeParser: Sendable {
         noticeStartDate < noticeEndDate
     else { return nil }
     
-    let range = noticeStartDate...noticeEndDate
-    guard range.contains(Date()) else { return nil }
-    
     return NoticeInfo(title: noticeAlertTitle,
                       message: noticeAlertMessage,
                       isAppTerminated: noticeAlertDismissedTerminate,

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -147,6 +147,23 @@ struct RemoteConfigParserTests {
     #expect(notice?.dateRange.contains(Date()) == false)
   }
 
+  @Test func remoteConfigParserParsesExpiredNoticeWithoutCheckingCurrentDate() {
+    let iso8601Style = Date.ISO8601FormatStyle()
+    let parser = RemoteConfigParser(
+      valueProvider: RemoteConfigClientMock(strings: [
+        "noticeAlertTitleKey": "Expired notice",
+        "noticeAlertMessageKey": "Scheduled maintenance",
+        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(-15000)),
+        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(-5000))
+      ])
+    )
+
+    let notice = parser.parse().notice
+
+    #expect(notice?.title == "Expired notice")
+    #expect(notice?.dateRange.contains(Date()) == false)
+  }
+
   @Test func fetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -225,6 +225,26 @@ struct RemoteConfigParserTests {
 
     #expect(status == .valid)
   }
+
+  @Test func fetchAppUpdateStatusReturnsValidForExpiredNotice() async throws {
+    let iso8601Style = Date.ISO8601FormatStyle()
+    let remoteConfigClient = RemoteConfigClientMock(
+      strings: [
+        "noticeAlertTitleKey": "Expired notice",
+        "noticeAlertMessageKey": "Scheduled maintenance",
+        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(-15000)),
+        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(-5000))
+      ]
+    )
+    let service = LaunchingService(
+      remoteConfigClient: remoteConfigClient,
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+    )
+
+    let status = try await service.fetchAppUpdateStatus()
+
+    #expect(status == .valid)
+  }
 }
 
 private enum RemoteConfigClientMockError: Error {

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -130,6 +130,23 @@ struct RemoteConfigParserTests {
     #expect(notice?.dateRange.contains(Date()) == true)
   }
 
+  @Test func remoteConfigParserParsesNoticeWithoutCheckingCurrentDate() {
+    let iso8601Style = Date.ISO8601FormatStyle()
+    let parser = RemoteConfigParser(
+      valueProvider: RemoteConfigClientMock(strings: [
+        "noticeAlertTitleKey": "Future notice",
+        "noticeAlertMessageKey": "Scheduled maintenance",
+        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(5000)),
+        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(15000))
+      ])
+    )
+
+    let notice = parser.parse().notice
+
+    #expect(notice?.title == "Future notice")
+    #expect(notice?.dateRange.contains(Date()) == false)
+  }
+
   @Test func fetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [
@@ -160,6 +177,26 @@ struct RemoteConfigParserTests {
     let remoteConfigClient = RemoteConfigClientMock(
       strings: [
         "blackListVersionsKey": "1.0.0"
+      ]
+    )
+    let service = LaunchingService(
+      remoteConfigClient: remoteConfigClient,
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+    )
+
+    let status = try await service.fetchAppUpdateStatus()
+
+    #expect(status == .valid)
+  }
+
+  @Test func fetchAppUpdateStatusReturnsValidForFutureNotice() async throws {
+    let iso8601Style = Date.ISO8601FormatStyle()
+    let remoteConfigClient = RemoteConfigClientMock(
+      strings: [
+        "noticeAlertTitleKey": "Future notice",
+        "noticeAlertMessageKey": "Scheduled maintenance",
+        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(5000)),
+        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(15000))
       ]
     )
     let service = LaunchingService(


### PR DESCRIPTION
## 변경 요약

- `RemoteConfigNoticeParser`에서 현재 시간 기준 Notice 활성 여부 검사를 제거했습니다.
- Notice 기간이 현재 시간에 활성인지 여부는 `NoticeChecker`가 단일하게 판단하도록 책임을 정리했습니다.
- 미래/과거 Notice가 parser 단계에서는 `NoticeInfo`로 유지되고, `fetchAppUpdateStatus()` 결과에서는 기간 밖 Notice가 `.valid`로 판정되는 테스트를 추가했습니다.
- CHANGELOG의 Unreleased 섹션에 후속 개선 내용을 기록했습니다.

## 의도

기존 구현은 `RemoteConfigNoticeParser`와 `NoticeChecker`가 모두 `dateRange.contains(Date())` 성격의 현재 시간 판정을 수행했습니다. parser는 Remote Config 값을 파싱해 모델을 만드는 책임만 갖고, 비즈니스 활성 여부 판단은 checker가 담당하는 편이 역할 분리가 명확합니다.

## 동작 영향

- 외부 API의 최종 `AppUpdateStatus` 결과는 유지됩니다.
- 내부 파싱 단계에서는 미래/과거 Notice도 유효한 날짜 범위라면 `NoticeInfo`로 보존됩니다.
- 최종 상태 판단에서 현재 기간 밖 Notice는 기존처럼 `.valid`로 처리됩니다.

## 검증

- `swift build`
- `swift test` - 40 tests passed
- `./GeneratingDocumentationSite`