### PR TITLE
refactor. NoticeChecker 날짜 제공자 주입

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 변경
 
 - Notice 활성 기간의 현재 시간 판정을 `NoticeChecker`로 단일화해 `RemoteConfigNoticeParser`가 Remote Config 값 파싱과 모델 생성만 담당하도록 정리했습니다.
+- `NoticeChecker`에 날짜 제공자 주입 경로를 추가해 Notice 활성 기간 테스트가 시스템 현재 시각에 직접 의존하지 않도록 개선했습니다.
 
 ## [0.9.3] - 2026-07-08
 

--- a/Sources/LaunchingService/Private/DateProvider.swift
+++ b/Sources/LaunchingService/Private/DateProvider.swift
@@ -1,0 +1,18 @@
+//
+//  DateProvider.swift
+//
+//
+//  Created by SwiftMan on 2026/07/08.
+//
+
+import Foundation
+
+protocol DateProviding: Sendable {
+  var now: Date { get }
+}
+
+struct SystemDateProvider: DateProviding {
+  var now: Date {
+    Date()
+  }
+}

--- a/Sources/LaunchingService/Private/LaunchingStatusComparator.swift
+++ b/Sources/LaunchingService/Private/LaunchingStatusComparator.swift
@@ -1,0 +1,27 @@
+//
+//  LaunchingStatusComparator.swift
+//
+//
+//  Created by SwiftMan on 2026/07/08.
+//
+
+import Foundation
+
+struct LaunchingStatusComparator: Sendable {
+  private let dateProvider: any DateProviding
+
+  init(dateProvider: any DateProviding = SystemDateProvider()) {
+    self.dateProvider = dateProvider
+  }
+
+  func compare(releaseVersion: String, launching: Launching) -> AppUpdateStatus {
+    var appStatus = AppUpdateStatusChecker().compare(releaseVersion: releaseVersion,
+                                                     launching: launching)
+
+    if appStatus == .valid {
+      appStatus = NoticeChecker(dateProvider: dateProvider).compare(launching: launching)
+    }
+
+    return appStatus
+  }
+}

--- a/Sources/LaunchingService/Private/NoticeChecker.swift
+++ b/Sources/LaunchingService/Private/NoticeChecker.swift
@@ -8,8 +8,14 @@
 import Foundation
 
 final class NoticeChecker: Sendable {
+  private let dateProvider: any DateProviding
+
+  init(dateProvider: any DateProviding = SystemDateProvider()) {
+    self.dateProvider = dateProvider
+  }
+
   func compare(launching: Launching) -> AppUpdateStatus {
-    if let notice = launching.notice, notice.dateRange.contains(Date()) {
+    if let notice = launching.notice, notice.dateRange.contains(dateProvider.now) {
       return .notice(NoticeAlert(title: notice.title,
                                  message: notice.message,
                                  isAppTerminated: notice.isAppTerminated,

--- a/Sources/LaunchingService/Private/NoticeChecker.swift
+++ b/Sources/LaunchingService/Private/NoticeChecker.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class NoticeChecker: Sendable {
+struct NoticeChecker: Sendable {
   private let dateProvider: any DateProviding
 
   init(dateProvider: any DateProviding = SystemDateProvider()) {

--- a/Sources/LaunchingService/Public/LaunchingInteractable.swift
+++ b/Sources/LaunchingService/Public/LaunchingInteractable.swift
@@ -19,11 +19,20 @@ public protocol LaunchingInteractable: AnyObject, Sendable {
 extension LaunchingInteractable {
   @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
   public func compare(releaseVersion: String, launching: Launching) -> AppUpdateStatus {
+    compare(releaseVersion: releaseVersion,
+            launching: launching,
+            dateProvider: SystemDateProvider())
+  }
+
+  @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
+  func compare(releaseVersion: String,
+               launching: Launching,
+               dateProvider: any DateProviding) -> AppUpdateStatus {
     var appStatus = AppUpdateStatusChecker().compare(releaseVersion: releaseVersion,
                                                      launching: launching)
     
     if appStatus == .valid {
-      appStatus = NoticeChecker().compare(launching: launching)
+      appStatus = NoticeChecker(dateProvider: dateProvider).compare(launching: launching)
     }
     
     return appStatus

--- a/Sources/LaunchingService/Public/LaunchingInteractable.swift
+++ b/Sources/LaunchingService/Public/LaunchingInteractable.swift
@@ -19,22 +19,7 @@ public protocol LaunchingInteractable: AnyObject, Sendable {
 extension LaunchingInteractable {
   @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
   public func compare(releaseVersion: String, launching: Launching) -> AppUpdateStatus {
-    compare(releaseVersion: releaseVersion,
-            launching: launching,
-            dateProvider: SystemDateProvider())
-  }
-
-  @available(iOS 15.0, macOS 12, tvOS 15, watchOS 8.0, *)
-  func compare(releaseVersion: String,
-               launching: Launching,
-               dateProvider: any DateProviding) -> AppUpdateStatus {
-    var appStatus = AppUpdateStatusChecker().compare(releaseVersion: releaseVersion,
-                                                     launching: launching)
-    
-    if appStatus == .valid {
-      appStatus = NoticeChecker(dateProvider: dateProvider).compare(launching: launching)
-    }
-    
-    return appStatus
+    LaunchingStatusComparator().compare(releaseVersion: releaseVersion,
+                                        launching: launching)
   }
 }

--- a/Sources/LaunchingService/Public/LaunchingService.swift
+++ b/Sources/LaunchingService/Public/LaunchingService.swift
@@ -21,7 +21,7 @@ public final class LaunchingService: LaunchingInteractable, Sendable {
 
   init(remoteConfigClient: any RemoteConfigClient,
        appVersionProvider: any AppReleaseVersionProviding,
-       dateProvider: any DateProviding = SystemDateProvider()) {
+       dateProvider: any DateProviding) {
     self.remoteConfigClient = remoteConfigClient
     self.appVersionProvider = appVersionProvider
     self.dateProvider = dateProvider

--- a/Sources/LaunchingService/Public/LaunchingService.swift
+++ b/Sources/LaunchingService/Public/LaunchingService.swift
@@ -40,8 +40,7 @@ public final class LaunchingService: LaunchingInteractable, Sendable {
 
     let releaseVersion = try appVersionProvider.releaseVersion()
     let launching = RemoteConfigParser(valueProvider: remoteConfigClient).parse()
-    return compare(releaseVersion: releaseVersion,
-                   launching: launching,
-                   dateProvider: dateProvider)
+    return LaunchingStatusComparator(dateProvider: dateProvider).compare(releaseVersion: releaseVersion,
+                                                                         launching: launching)
   }
 }

--- a/Sources/LaunchingService/Public/LaunchingService.swift
+++ b/Sources/LaunchingService/Public/LaunchingService.swift
@@ -10,17 +10,21 @@
 public final class LaunchingService: LaunchingInteractable, Sendable {
   private let remoteConfigClient: any RemoteConfigClient
   private let appVersionProvider: any AppReleaseVersionProviding
+  private let dateProvider: any DateProviding
 
   /// Creates an instance with the given alignment.
   public init() {
     self.remoteConfigClient = FirebaseRemoteConfigClient()
     self.appVersionProvider = MainBundleReleaseVersionProvider()
+    self.dateProvider = SystemDateProvider()
   }
 
   init(remoteConfigClient: any RemoteConfigClient,
-       appVersionProvider: any AppReleaseVersionProviding) {
+       appVersionProvider: any AppReleaseVersionProviding,
+       dateProvider: any DateProviding = SystemDateProvider()) {
     self.remoteConfigClient = remoteConfigClient
     self.appVersionProvider = appVersionProvider
+    self.dateProvider = dateProvider
   }
 
   /// Firebase - RemoteConfig 의 값을 가져오고 계산 된 앱의 상태를 반환 합니다.
@@ -36,6 +40,8 @@ public final class LaunchingService: LaunchingInteractable, Sendable {
 
     let releaseVersion = try appVersionProvider.releaseVersion()
     let launching = RemoteConfigParser(valueProvider: remoteConfigClient).parse()
-    return compare(releaseVersion: releaseVersion, launching: launching)
+    return compare(releaseVersion: releaseVersion,
+                   launching: launching,
+                   dateProvider: dateProvider)
   }
 }

--- a/Tests/LaunchingServiceTests/DateProviderMock.swift
+++ b/Tests/LaunchingServiceTests/DateProviderMock.swift
@@ -1,0 +1,13 @@
+//
+//  DateProviderMock.swift
+//
+//
+//  Created by SwiftMan on 2026/07/08.
+//
+
+import Foundation
+@testable import LaunchingService
+
+struct DateProviderMock: DateProviding {
+  let now: Date
+}

--- a/Tests/LaunchingServiceTests/LaunchingServiceMock.swift
+++ b/Tests/LaunchingServiceTests/LaunchingServiceMock.swift
@@ -6,21 +6,26 @@
 //
 
 import Foundation
-import LaunchingService
+@testable import LaunchingService
 
 @MainActor
 final class LaunchingServiceMock: LaunchingInteractable, Sendable {
   let releaseVersion: String
   let launching: Launching
+  let dateProvider: any DateProviding
   
   init(releaseVersion: String,
-       launching: Launching) {
+       launching: Launching,
+       dateProvider: any DateProviding = SystemDateProvider()) {
     self.releaseVersion = releaseVersion
     self.launching = launching
+    self.dateProvider = dateProvider
   }
   
   func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
-    return compare(releaseVersion: releaseVersion, launching: launching)
+    return compare(releaseVersion: releaseVersion,
+                   launching: launching,
+                   dateProvider: dateProvider)
   }
 }
 

--- a/Tests/LaunchingServiceTests/LaunchingServiceMock.swift
+++ b/Tests/LaunchingServiceTests/LaunchingServiceMock.swift
@@ -16,7 +16,7 @@ final class LaunchingServiceMock: LaunchingInteractable, Sendable {
   
   init(releaseVersion: String,
        launching: Launching,
-       dateProvider: any DateProviding = SystemDateProvider()) {
+       dateProvider: any DateProviding) {
     self.releaseVersion = releaseVersion
     self.launching = launching
     self.dateProvider = dateProvider

--- a/Tests/LaunchingServiceTests/LaunchingServiceMock.swift
+++ b/Tests/LaunchingServiceTests/LaunchingServiceMock.swift
@@ -23,9 +23,8 @@ final class LaunchingServiceMock: LaunchingInteractable, Sendable {
   }
   
   func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
-    return compare(releaseVersion: releaseVersion,
-                   launching: launching,
-                   dateProvider: dateProvider)
+    return LaunchingStatusComparator(dateProvider: dateProvider).compare(releaseVersion: releaseVersion,
+                                                                         launching: launching)
   }
 }
 

--- a/Tests/LaunchingServiceTests/LaunchingServiceTests.swift
+++ b/Tests/LaunchingServiceTests/LaunchingServiceTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Testing
-import LaunchingService
+@testable import LaunchingService
 
 @Suite("LaunchingService")
 @MainActor
@@ -46,6 +46,7 @@ func expectAppUpdateStatus(releaseVersion: String,
                            optionalUpdate: String,
                            blackListVersions: [String],
                            notice: NoticeInfo?,
+                           dateProvider: any DateProviding = SystemDateProvider(),
                            isEqualStatus: AppUpdateStatus) async throws {
   let service = LaunchingServiceMock(releaseVersion: releaseVersion,
                                      launching: Launching(forceUpdate: AppUpdateInfo(version: forceVersion,
@@ -57,7 +58,8 @@ func expectAppUpdateStatus(releaseVersion: String,
                                                                                         alertMessage: "",
                                                                                         alertDoneLinkURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
                                                           blackListVersions: blackListVersions,
-                                                          notice: notice))
+                                                          notice: notice),
+                                     dateProvider: dateProvider)
 
   let appStatus = try await service.fetchAppUpdateStatus()
   #expect(appStatus == isEqualStatus)

--- a/Tests/LaunchingServiceTests/LaunchingServiceTests.swift
+++ b/Tests/LaunchingServiceTests/LaunchingServiceTests.swift
@@ -46,7 +46,7 @@ func expectAppUpdateStatus(releaseVersion: String,
                            optionalUpdate: String,
                            blackListVersions: [String],
                            notice: NoticeInfo?,
-                           dateProvider: any DateProviding = SystemDateProvider(),
+                           dateProvider: any DateProviding = DateProviderMock(now: Date(timeIntervalSince1970: 1_704_067_200)),
                            isEqualStatus: AppUpdateStatus) async throws {
   let service = LaunchingServiceMock(releaseVersion: releaseVersion,
                                      launching: Launching(forceUpdate: AppUpdateInfo(version: forceVersion,

--- a/Tests/LaunchingServiceTests/NoticeTests.swift
+++ b/Tests/LaunchingServiceTests/NoticeTests.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 import Testing
-import LaunchingService
+@testable import LaunchingService
 
 @Suite("Notice")
 @MainActor
 struct NoticeTests {
+  private static let referenceDate = Date(timeIntervalSince1970: 1_704_067_200)
+
   @Test func notice_1() async throws {
     let title = "title"
     let message = "message"
@@ -25,8 +27,9 @@ struct NoticeTests {
                                     notice: NoticeInfo(title: title,
                                                        message: message,
                                                        isAppTerminated: isAppTerminated,
-                                                       dateRange: Date().addingTimeInterval(-5000) ... Date().addingTimeInterval(5000),
+                                                       dateRange: Self.referenceDate.addingTimeInterval(-5000) ... Self.referenceDate.addingTimeInterval(5000),
                                                        doneURL: doneURL),
+                                    dateProvider: DateProviderMock(now: Self.referenceDate),
                                     isEqualStatus: .notice(NoticeAlert(title: title,
                                                                        message: message,
                                                                        isAppTerminated: isAppTerminated,
@@ -41,8 +44,9 @@ struct NoticeTests {
                                     notice: NoticeInfo(title: "title",
                                                        message: "message",
                                                        isAppTerminated: true,
-                                                       dateRange: Date().addingTimeInterval(5000) ... Date().addingTimeInterval(15000),
+                                                       dateRange: Self.referenceDate.addingTimeInterval(5000) ... Self.referenceDate.addingTimeInterval(15000),
                                                        doneURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
+                                    dateProvider: DateProviderMock(now: Self.referenceDate),
                                     isEqualStatus: .valid)
   }
   
@@ -54,8 +58,9 @@ struct NoticeTests {
                                     notice: NoticeInfo(title: "title",
                                                        message: "message",
                                                        isAppTerminated: true,
-                                                       dateRange: Date().addingTimeInterval(-15000) ... Date().addingTimeInterval(-10000),
+                                                       dateRange: Self.referenceDate.addingTimeInterval(-15000) ... Self.referenceDate.addingTimeInterval(-10000),
                                                        doneURL: URL(string: "https://github.com/swift-man/LaunchingService")!),
+                                    dateProvider: DateProviderMock(now: Self.referenceDate),
                                     isEqualStatus: .valid)
   }
 }

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -210,6 +210,39 @@ struct RemoteConfigParserTests {
     #expect(status == .valid)
   }
 
+  @Test func fetchAppUpdateStatusReturnsNoticeForActiveNotice() async throws {
+    let iso8601Style = Date.ISO8601FormatStyle()
+    let doneURL = URL(string: "https://example.com/notice")!
+    let remoteConfigClient = RemoteConfigClientMock(
+      strings: [
+        "noticeAlertTitleKey": "Active notice",
+        "noticeAlertMessageKey": "Scheduled maintenance",
+        "noticeStartDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(-5000)),
+        "noticeEndDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(5000)),
+        "noticeAlertDoneURLKey": doneURL.absoluteString
+      ],
+      bools: [
+        "noticeAlertDismissedTerminateKey": true
+      ]
+    )
+    let service = LaunchingService(
+      remoteConfigClient: remoteConfigClient,
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0"),
+      dateProvider: DateProviderMock(now: Self.referenceDate)
+    )
+
+    let status = try await service.fetchAppUpdateStatus()
+
+    #expect(
+      status == .notice(
+        NoticeAlert(title: "Active notice",
+                    message: "Scheduled maintenance",
+                    isAppTerminated: true,
+                    doneURL: doneURL)
+      )
+    )
+  }
+
   @Test func fetchAppUpdateStatusReturnsValidForFutureNotice() async throws {
     let iso8601Style = Date.ISO8601FormatStyle()
     let remoteConfigClient = RemoteConfigClientMock(

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -12,6 +12,8 @@ import Testing
 @Suite("RemoteConfigParser")
 @MainActor
 struct RemoteConfigParserTests {
+  private static let referenceDate = Date(timeIntervalSince1970: 1_704_067_200)
+
   @Test func forceUpdateParserKeepsAlertInfoWhenForceVersionIsMissing() {
     let parser = RemoteConfigForceUpdateParser(
       keyStore: RemoteConfigRegisterdKeys(),
@@ -90,8 +92,8 @@ struct RemoteConfigParserTests {
         strings: [
           "noticeAlertTitleKey": "Notice",
           "noticeAlertMessageKey": "Scheduled maintenance",
-          "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(-5000)),
-          "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(5000)),
+          "noticeStartDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(-5000)),
+          "noticeEndDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(5000)),
           "noticeAlertDoneURLKey": doneURL.absoluteString
         ],
         bools: [
@@ -106,7 +108,7 @@ struct RemoteConfigParserTests {
     #expect(notice?.message == "Scheduled maintenance")
     #expect(notice?.isAppTerminated == true)
     #expect(notice?.doneURL == doneURL)
-    #expect(notice?.dateRange.contains(Date()) == true)
+    #expect(notice?.dateRange.contains(Self.referenceDate) == true)
   }
 
   @Test func remoteConfigParserContinuesToParseNoticeDatesWithCompactTimeZone() {
@@ -119,15 +121,15 @@ struct RemoteConfigParserTests {
       valueProvider: RemoteConfigClientMock(strings: [
         "noticeAlertTitleKey": "Notice",
         "noticeAlertMessageKey": "Scheduled maintenance",
-        "noticeStartDateKey": dateFormatter.string(from: Date().addingTimeInterval(-5000)),
-        "noticeEndDateKey": dateFormatter.string(from: Date().addingTimeInterval(5000))
+        "noticeStartDateKey": dateFormatter.string(from: Self.referenceDate.addingTimeInterval(-5000)),
+        "noticeEndDateKey": dateFormatter.string(from: Self.referenceDate.addingTimeInterval(5000))
       ])
     )
 
     let notice = parser.parse().notice
 
     #expect(notice?.title == "Notice")
-    #expect(notice?.dateRange.contains(Date()) == true)
+    #expect(notice?.dateRange.contains(Self.referenceDate) == true)
   }
 
   @Test func remoteConfigParserParsesNoticeWithoutCheckingCurrentDate() {
@@ -136,15 +138,15 @@ struct RemoteConfigParserTests {
       valueProvider: RemoteConfigClientMock(strings: [
         "noticeAlertTitleKey": "Future notice",
         "noticeAlertMessageKey": "Scheduled maintenance",
-        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(5000)),
-        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(15000))
+        "noticeStartDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(5000)),
+        "noticeEndDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(15000))
       ])
     )
 
     let notice = parser.parse().notice
 
     #expect(notice?.title == "Future notice")
-    #expect(notice?.dateRange.contains(Date()) == false)
+    #expect(notice?.dateRange.contains(Self.referenceDate) == false)
   }
 
   @Test func remoteConfigParserParsesExpiredNoticeWithoutCheckingCurrentDate() {
@@ -153,15 +155,15 @@ struct RemoteConfigParserTests {
       valueProvider: RemoteConfigClientMock(strings: [
         "noticeAlertTitleKey": "Expired notice",
         "noticeAlertMessageKey": "Scheduled maintenance",
-        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(-15000)),
-        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(-5000))
+        "noticeStartDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(-15000)),
+        "noticeEndDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(-5000))
       ])
     )
 
     let notice = parser.parse().notice
 
     #expect(notice?.title == "Expired notice")
-    #expect(notice?.dateRange.contains(Date()) == false)
+    #expect(notice?.dateRange.contains(Self.referenceDate) == false)
   }
 
   @Test func fetchAppUpdateStatusContinuesWithCachedConfigWhenFetchFails() async throws {
@@ -212,13 +214,14 @@ struct RemoteConfigParserTests {
       strings: [
         "noticeAlertTitleKey": "Future notice",
         "noticeAlertMessageKey": "Scheduled maintenance",
-        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(5000)),
-        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(15000))
+        "noticeStartDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(5000)),
+        "noticeEndDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(15000))
       ]
     )
     let service = LaunchingService(
       remoteConfigClient: remoteConfigClient,
-      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0"),
+      dateProvider: DateProviderMock(now: Self.referenceDate)
     )
 
     let status = try await service.fetchAppUpdateStatus()
@@ -232,13 +235,14 @@ struct RemoteConfigParserTests {
       strings: [
         "noticeAlertTitleKey": "Expired notice",
         "noticeAlertMessageKey": "Scheduled maintenance",
-        "noticeStartDateKey": iso8601Style.format(Date().addingTimeInterval(-15000)),
-        "noticeEndDateKey": iso8601Style.format(Date().addingTimeInterval(-5000))
+        "noticeStartDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(-15000)),
+        "noticeEndDateKey": iso8601Style.format(Self.referenceDate.addingTimeInterval(-5000))
       ]
     )
     let service = LaunchingService(
       remoteConfigClient: remoteConfigClient,
-      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0"),
+      dateProvider: DateProviderMock(now: Self.referenceDate)
     )
 
     let status = try await service.fetchAppUpdateStatus()

--- a/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
+++ b/Tests/LaunchingServiceTests/RemoteConfigParserTests.swift
@@ -178,7 +178,8 @@ struct RemoteConfigParserTests {
     )
     let service = LaunchingService(
       remoteConfigClient: remoteConfigClient,
-      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0"),
+      dateProvider: DateProviderMock(now: Self.referenceDate)
     )
 
     let status = try await service.fetchAppUpdateStatus()
@@ -200,7 +201,8 @@ struct RemoteConfigParserTests {
     )
     let service = LaunchingService(
       remoteConfigClient: remoteConfigClient,
-      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0")
+      appVersionProvider: AppReleaseVersionProviderMock(version: "1.0.0"),
+      dateProvider: DateProviderMock(now: Self.referenceDate)
     )
 
     let status = try await service.fetchAppUpdateStatus()


### PR DESCRIPTION
## 변경 요약

- `DateProviding` / `SystemDateProvider`를 추가해 Notice 활성 판정의 현재 시각 조회를 주입 가능하게 했습니다.
- `NoticeChecker`는 날짜 제공자를 통해 현재 시각을 받고, `LaunchingStatusComparator`가 AppUpdateStatus 판정과 Notice 판정 조합을 담당하도록 분리했습니다.
- `LaunchingService`의 테스트용 internal init에 날짜 제공자를 전달해 공개 API 변경 없이 서비스 레벨 Notice 테스트를 고정 시각으로 검증하도록 개선했습니다.
- Notice 및 RemoteConfigParser 테스트에서 `Date()` 상대값 대신 기준 시각과 `DateProviderMock`을 사용하도록 정리했습니다.
- CHANGELOG Unreleased에 후속 개선 내용을 기록했습니다.

## 의도

직전 PR에서 Notice 활성 기간 판정 책임을 `NoticeChecker`로 모았지만, 테스트는 여전히 시스템 현재 시각에 상대적인 날짜를 만들고 있었습니다. 이번 변경은 시간 의존성을 내부 주입 지점으로 분리해 경계 시각 테스트가 벽시계 변화에 덜 흔들리도록 만드는 후속 개선입니다.

## 공개 API 영향

- 공개 `LaunchingService` 초기화와 `LaunchingInteractable.compare(releaseVersion:launching:)` 시그니처는 유지했습니다.
- 날짜 제공자 주입은 internal/testable 경로로만 열어 외부 사용자 API를 넓히지 않았습니다.

## 리뷰 반영

- provider-aware compare 로직을 프로토콜 extension overload가 아닌 `LaunchingStatusComparator` 내부 타입으로 분리했습니다.
- 테스트 헬퍼의 기본 날짜 제공자를 `SystemDateProvider`에서 고정 시각 mock으로 바꿨습니다.

## 검증

- `swift build`
- `swift test` - 41 tests passed
- `./GeneratingDocumentationSite`